### PR TITLE
Admin Mega Menu publish-hardening (validation + storefront parity)

### DIFF
--- a/backend/routes/megaMenuRoutes.js
+++ b/backend/routes/megaMenuRoutes.js
@@ -111,6 +111,106 @@ async function obsLog(event) {
   }
 }
 
+const ALLOWED_STATUS = new Set(['active', 'hidden']);
+
+function sanitizeText(v) {
+  return typeof v === 'string' ? v.trim() : '';
+}
+
+function isSafeLinkTarget(to) {
+  const value = sanitizeText(to);
+  if (!value) return false;
+  if (/^(javascript|data):/i.test(value)) return false;
+  return value.startsWith('/') || /^https?:\/\//i.test(value);
+}
+
+function validateMegaMenuPayload(body) {
+  const errors = [];
+  if (!body || !Array.isArray(body.menu)) {
+    return {
+      errors: [{ path: 'menu', message: 'menu must be an array' }],
+      menu: [],
+    };
+  }
+
+  const seenTitles = new Set();
+  const normalizedMenu = body.menu.map((col, colIdx) => {
+    const pathPrefix = `menu[${colIdx}]`;
+    if (!col || typeof col !== 'object' || Array.isArray(col)) {
+      errors.push({ path: pathPrefix, message: 'category must be an object' });
+      return { title: '', icon: '', status: 'active', links: [] };
+    }
+
+    const title = sanitizeText(col.title);
+    if (!title) {
+      errors.push({ path: `${pathPrefix}.title`, message: 'title is required' });
+    } else {
+      const key = title.toLowerCase();
+      if (seenTitles.has(key)) {
+        errors.push({ path: `${pathPrefix}.title`, message: 'title must be unique' });
+      }
+      seenTitles.add(key);
+    }
+
+    const status = sanitizeText(col.status || 'active') || 'active';
+    if (!ALLOWED_STATUS.has(status)) {
+      errors.push({ path: `${pathPrefix}.status`, message: "status must be 'active' or 'hidden'" });
+    }
+
+    const links = Array.isArray(col.links) ? col.links : [];
+    if (!Array.isArray(col.links)) {
+      errors.push({ path: `${pathPrefix}.links`, message: 'links must be an array' });
+    }
+
+    const normalizedLinks = links.map((lnk, linkIdx) => {
+      const linkPath = `${pathPrefix}.links[${linkIdx}]`;
+      if (!lnk || typeof lnk !== 'object' || Array.isArray(lnk)) {
+        errors.push({ path: linkPath, message: 'link must be an object' });
+        return { label: '', to: '', status: 'active' };
+      }
+
+      const label = sanitizeText(lnk.label);
+      if (!label) {
+        errors.push({ path: `${linkPath}.label`, message: 'label is required' });
+      }
+
+      const to = sanitizeText(lnk.to);
+      if (!isSafeLinkTarget(to)) {
+        errors.push({ path: `${linkPath}.to`, message: 'link target must start with / or http(s):// and cannot use javascript:/data:' });
+      }
+
+      const linkStatus = sanitizeText(lnk.status || 'active') || 'active';
+      if (!ALLOWED_STATUS.has(linkStatus)) {
+        errors.push({ path: `${linkPath}.status`, message: "status must be 'active' or 'hidden'" });
+      }
+
+      return {
+        label,
+        to,
+        status: ALLOWED_STATUS.has(linkStatus) ? linkStatus : 'active',
+        icon: typeof lnk.icon === 'string' ? lnk.icon : undefined,
+        thumb: typeof lnk.thumb === 'string' ? lnk.thumb : undefined,
+        label_en: typeof lnk.label_en === 'string' ? lnk.label_en.trim() : undefined,
+        label_am: typeof lnk.label_am === 'string' ? lnk.label_am.trim() : undefined,
+        label_or: typeof lnk.label_or === 'string' ? lnk.label_or.trim() : undefined,
+      };
+    });
+
+    return {
+      title,
+      status: ALLOWED_STATUS.has(status) ? status : 'active',
+      icon: typeof col.icon === 'string' ? col.icon : undefined,
+      thumb: typeof col.thumb === 'string' ? col.thumb : undefined,
+      title_en: typeof col.title_en === 'string' ? col.title_en.trim() : undefined,
+      title_am: typeof col.title_am === 'string' ? col.title_am.trim() : undefined,
+      title_or: typeof col.title_or === 'string' ? col.title_or.trim() : undefined,
+      links: normalizedLinks,
+    };
+  });
+
+  return { errors, menu: normalizedMenu };
+}
+
 // Public endpoint: GET /api/categories -> simplified active menu for frontend
 router.get('/categories', async (req, res) => {
   try {
@@ -262,10 +362,14 @@ router.get('/admin/mega-menu', protect, authorize('admin', 'global_admin'), asyn
 router.put('/admin/mega-menu', protect, authorize('admin', 'global_admin'), async (req, res) => {
   try {
     const body = req.body || {};
-    if (!Array.isArray(body.menu)) {
-      return res.status(400).json({ message: 'Invalid payload: menu array required' });
+    const { errors, menu } = validateMegaMenuPayload(body);
+    if (errors.length) {
+      return res.status(422).json({
+        message: 'Invalid mega menu payload',
+        errors,
+      });
     }
-    const saved = await writeMenuFile({ menu: body.menu });
+    const saved = await writeMenuFile({ menu });
     await appendAudit(req.user, 'save', saved);
     res.json(saved);
   } catch (err) {

--- a/backend/tests/integration/megaMenuRoutes.test.js
+++ b/backend/tests/integration/megaMenuRoutes.test.js
@@ -140,13 +140,39 @@ describe('Mega Menu Routes @mega-menu', () => {
   });
 
   describe('Admin: PUT /api/admin/mega-menu', () => {
-    test('400 when payload missing menu array', async () => {
+    test('422 when payload missing menu array', async () => {
       const res = await request(app)
         .put('/api/admin/mega-menu')
         .set('Authorization', adminToken)
         .send({});
-      expect(res.statusCode).toBe(400);
-      expect(res.body.message).toMatch(/menu array required/i);
+      expect(res.statusCode).toBe(422);
+      expect(res.body.message).toMatch(/invalid mega menu payload/i);
+      expect(Array.isArray(res.body.errors)).toBe(true);
+      expect(res.body.errors.some((e) => e.path === 'menu')).toBe(true);
+    });
+
+    test('422 with field-level errors for invalid category/link fields', async () => {
+      const res = await request(app)
+        .put('/api/admin/mega-menu')
+        .set('Authorization', adminToken)
+        .send({
+          menu: [
+            {
+              title: '   ',
+              status: 'active',
+              links: [
+                { label: '', to: 'javascript:alert(1)', status: 'active' },
+              ],
+            },
+          ],
+        });
+
+      expect(res.statusCode).toBe(422);
+      expect(res.body.message).toMatch(/invalid mega menu payload/i);
+      expect(Array.isArray(res.body.errors)).toBe(true);
+      expect(res.body.errors.some((e) => e.path === 'menu[0].title')).toBe(true);
+      expect(res.body.errors.some((e) => e.path === 'menu[0].links[0].label')).toBe(true);
+      expect(res.body.errors.some((e) => e.path === 'menu[0].links[0].to')).toBe(true);
     });
 
     test('200 saves provided menu and returns normalized payload', async () => {

--- a/docs/issues/admin-mega-menu-publish-hardening-slice.md
+++ b/docs/issues/admin-mega-menu-publish-hardening-slice.md
@@ -1,0 +1,38 @@
+# Admin Mega Menu publish-hardening (validation + storefront parity)
+
+Scope (strict)
+- strict backend validation for PUT /api/admin/mega-menu
+- storefront parity so shopper-facing navbar/category rendering uses server-managed data
+- validation feedback in AdminMegaMenu
+- targeted backend/frontend test coverage for invalid payloads and parity
+
+Out of scope
+- AdminCategories placeholder implementation work
+
+Acceptance Criteria
+- Backend hardening
+  - PUT /api/admin/mega-menu rejects invalid payloads with 422 and field-level error details (not just generic 400).
+  - Valid payload persists and remains readable by GET /api/admin/mega-menu.
+- Storefront parity
+  - Public navbar category panel reflects backend-updated mega menu without manual localStorage intervention.
+  - Hidden categories/links remain excluded in shopper view.
+- Regression safety
+  - Existing mega-menu integration tests remain green.
+  - New tests cover at least one invalid payload case and one end-to-end parity check (admin save -> public read/render path).
+
+Proof Path
+Manual proof
+1. Login as admin, open /admin/mega-menu.
+2. Submit an invalid payload case (for example empty title or malformed link target), confirm clear validation error and no save.
+3. Submit a valid change (rename one category and add one valid link), confirm success.
+4. Open public homepage in a separate clean session, open Shop by Category, verify updated category/link appears.
+5. Call GET /api/categories and verify returned menu/categories match the change.
+6. Confirm audit endpoint shows the save event in /api/admin/mega-menu/audit.
+
+Automated proof
+1. Backend:
+   - Run existing + new mega-menu integration tests from backend/tests/integration/megaMenuRoutes.test.js.
+   - Expected: all pass; includes new 422 validation assertions.
+2. Frontend:
+   - Add/extend navbar test coverage (existing pattern in frontend/src/__tests__/unit/components/MerkatoNavbar.vendorSearch.test.js) to assert server-backed category rendering path.
+   - Expected: updated menu values are rendered from API response and fallback behavior remains stable.

--- a/frontend/src/__tests__/unit/components/MerkatoNavbar.serverMegaMenuParity.test.js
+++ b/frontend/src/__tests__/unit/components/MerkatoNavbar.serverMegaMenuParity.test.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import axios from 'axios';
+import MerkatoNavbar from '../../../components/MerkatoNavbar.jsx';
+
+function App() {
+  return (
+    <MemoryRouter initialEntries={["/"]}>
+      <Routes>
+        <Route path="/" element={<MerkatoNavbar role="public" />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('MerkatoNavbar server mega menu parity', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+
+    axios.get.mockImplementation((url) => {
+      if (typeof url === 'string' && url.startsWith('/api/categories')) {
+        return Promise.resolve({
+          status: 200,
+          headers: {},
+          data: {
+            menu: [
+              {
+                title: 'Server Category',
+                icon: '🧪',
+                links: [{ label: 'Server Link', to: '/shop?category=server' }],
+              },
+            ],
+            categories: [
+              {
+                id: 'server-category',
+                name: 'Server Category',
+                slug: 'server-category',
+                level: 1,
+                displayOrder: 10,
+                visibleIn: ['mega', 'searchbar'],
+                active: true,
+              },
+            ],
+            updatedAt: '2026-04-04T00:00:00.000Z',
+            version: 1,
+          },
+        });
+      }
+
+      return Promise.resolve({ data: {} });
+    });
+  });
+
+  test('renders server-managed mega menu category in shopper navbar', async () => {
+    render(<App />);
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalledWith('/api/categories');
+    });
+
+    const trigger = screen.getByRole('button', { name: /Shop by Category/i });
+    fireEvent.click(trigger);
+
+    expect(await screen.findByRole('tab', { name: /Server Category/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Server Link/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/MerkatoNavbar.jsx
+++ b/frontend/src/components/MerkatoNavbar.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useCart } from '../cart/CartContext';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import MEGA_MENU from '../config/megaMenu';
+import { fetchCategories } from '../api/categories';
 import { getCanonicalTaxonomy, getCategoryListFrom } from '../utils/taxonomy';
 import MegaMenuPromoPanel from './MegaMenuPromoPanel.js';
 import { fetchSearchSuggest, logSearchEvent } from '../api/search';
@@ -297,63 +298,47 @@ function MerkatoNavbar({ role: roleProp = 'public', showCategories: showCategori
 		} catch (_) {}
 	};
 
-	// Admin/CMS override: allow MEGA_MENU to be replaced via localStorage JSON
+	// Track menu refresh requests from admin save actions.
 	const [menuVersion, setMenuVersion] = useState(0);
+	const [serverMegaMenu, setServerMegaMenu] = useState([]);
 	useEffect(() => {
-		const onStorage = (e) => {
-			if (e && e.key && e.key !== 'merkato-mega-menu') return;
-			setMenuVersion((v) => v + 1);
-		};
 		const onCustom = () => setMenuVersion((v) => v + 1);
-		window.addEventListener('storage', onStorage);
 		window.addEventListener('mega-menu:updated', onCustom);
 		return () => {
-			window.removeEventListener('storage', onStorage);
 			window.removeEventListener('mega-menu:updated', onCustom);
 		};
 	}, []);
 
-	const effectiveMegaMenu = useMemo(() => {
-		const normalizeCols = (arr) => (Array.isArray(arr) ? arr : []);
-		const mergeWithDefault = (overrideArr) => {
-			const base = MEGA_MENU;
-			const ov = normalizeCols(overrideArr);
-			const merged = base.map((defCol, i) => {
-				const o = ov[i] || {};
-				const oLinks = Array.isArray(o.links) ? o.links : [];
-				const links = oLinks.length ? oLinks : defCol.links;
-				return {
-					title: (o.title ?? defCol.title) || defCol.title,
-					icon: o.icon ?? defCol.icon,
-					thumb: o.thumb ?? defCol.thumb,
-					links,
-				};
-			});
-			// Append any extra override columns beyond defaults
-			if (ov.length > base.length) {
-				for (let j = base.length; j < ov.length; j++) {
-					const extra = ov[j];
-					merged.push({
-						title: extra?.title ?? '',
-						icon: extra?.icon,
-						thumb: extra?.thumb,
-						links: Array.isArray(extra?.links) ? extra.links : [],
-					});
-				}
+	useEffect(() => {
+		if (isVendor) return;
+		let mounted = true;
+		const loadServerMegaMenu = async () => {
+			try {
+				const menu = await fetchCategories();
+				if (!mounted) return;
+				setServerMegaMenu(Array.isArray(menu) ? menu : []);
+			} catch (_) {
+				if (!mounted) return;
+				setServerMegaMenu([]);
 			}
-			// If all columns somehow have empty links, fallback entirely to base
-			const anyLinks = merged.some((c) => Array.isArray(c.links) && c.links.length > 0);
-			return anyLinks ? merged : base;
 		};
-		try {
-			const raw = localStorage.getItem('merkato-mega-menu');
-			if (raw) {
-				const parsed = JSON.parse(raw);
-				if (Array.isArray(parsed)) return mergeWithDefault(parsed);
-			}
-		} catch (_) {}
+		loadServerMegaMenu();
+		return () => {
+			mounted = false;
+		};
+	}, [isVendor, menuVersion]);
+
+	const effectiveMegaMenu = useMemo(() => {
+		if (Array.isArray(serverMegaMenu) && serverMegaMenu.length > 0) {
+			return serverMegaMenu.map((col) => ({
+				title: col?.title || '',
+				icon: col?.icon,
+				thumb: col?.thumb,
+				links: Array.isArray(col?.links) ? col.links : [],
+			}));
+		}
 		return MEGA_MENU;
-	}, [menuVersion]);
+	}, [serverMegaMenu]);
 
 	// Support SPA navigation when promo panel dispatches navigate intent
 	useEffect(() => {

--- a/frontend/src/pages/AdminMegaMenu.jsx
+++ b/frontend/src/pages/AdminMegaMenu.jsx
@@ -153,6 +153,7 @@ export default function AdminMegaMenu() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
+  const [fieldErrors, setFieldErrors] = useState([]);
   const [message, setMessage] = useState('');
   const [audit, setAudit] = useState([]);
 
@@ -206,14 +207,18 @@ export default function AdminMegaMenu() {
   const save = async () => {
     setSaving(true);
     setError('');
+    setFieldErrors([]);
     setMessage('');
     try {
       const payload = { menu: Array.isArray(menu) ? menu : [] };
       const res = await axios.put('/api/admin/mega-menu', payload, { headers });
       setUpdatedAt(res.data?.updatedAt || '');
       setMessage('Saved successfully.');
+      window.dispatchEvent(new CustomEvent('mega-menu:updated'));
     } catch (e) {
       setError(e?.response?.data?.message || e?.message || 'Failed to save');
+      const errs = Array.isArray(e?.response?.data?.errors) ? e.response.data.errors : [];
+      setFieldErrors(errs);
     } finally {
       setSaving(false);
     }
@@ -245,6 +250,16 @@ export default function AdminMegaMenu() {
 
       {error && (
         <div style={{ background: '#fee2e2', color: '#991b1b', padding: 10, borderRadius: 6, marginBottom: 12 }}>{error}</div>
+      )}
+      {!!fieldErrors.length && (
+        <div data-testid="validation-errors" style={{ background: '#fff7ed', color: '#9a3412', padding: 10, borderRadius: 6, marginBottom: 12 }}>
+          <div style={{ fontWeight: 600, marginBottom: 6 }}>Validation details</div>
+          <ul style={{ margin: 0, paddingLeft: 18 }}>
+            {fieldErrors.map((err, idx) => (
+              <li key={`ferr-${idx}`}>{`${err.path}: ${err.message}`}</li>
+            ))}
+          </ul>
+        </div>
       )}
       {message && (
         <div style={{ background: '#ecfdf5', color: '#065f46', padding: 10, borderRadius: 6, marginBottom: 12 }}>{message}</div>

--- a/frontend/src/pages/__tests__/AdminMegaMenu.validation.test.js
+++ b/frontend/src/pages/__tests__/AdminMegaMenu.validation.test.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import axios from 'axios';
+import AdminMegaMenu from '../AdminMegaMenu';
+
+describe('AdminMegaMenu validation feedback', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    localStorage.setItem('token', 'test-token');
+  });
+
+  test('shows field-level validation feedback returned by backend', async () => {
+    axios.get.mockResolvedValueOnce({
+      data: {
+        menu: [
+          { title: 'Electronics', status: 'active', links: [{ label: 'Phones', to: '/shop?category=electronics' }] },
+        ],
+        updatedAt: new Date().toISOString(),
+      },
+    });
+
+    axios.put.mockRejectedValueOnce({
+      response: {
+        data: {
+          message: 'Invalid mega menu payload',
+          errors: [
+            { path: 'menu[0].title', message: 'title is required' },
+            { path: 'menu[0].links[0].to', message: 'link target must start with / or http(s):// and cannot use javascript:/data:' },
+          ],
+        },
+      },
+    });
+
+    render(<AdminMegaMenu />);
+
+    fireEvent.click(await screen.findByTestId('save-megamenu'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Invalid mega menu payload/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('validation-errors')).toBeInTheDocument();
+    expect(screen.getByText(/menu\[0\]\.title: title is required/i)).toBeInTheDocument();
+    expect(screen.getByText(/menu\[0\]\.links\[0\]\.to/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #36\n\n## Slice Title\nAdmin Mega Menu publish-hardening (validation + storefront parity)\n\n## Scoped Slice (strict)\n- strict backend validation for PUT /api/admin/mega-menu\n- storefront parity so shopper-facing navbar/category rendering uses server-managed data\n- validation feedback in AdminMegaMenu\n- targeted backend/frontend test coverage for invalid payloads and parity\n\n## Explicitly Out of Scope\n- AdminCategories placeholder implementation work\n\n## Acceptance Criteria\n- Backend hardening\n  - PUT /api/admin/mega-menu rejects invalid payloads with 422 and field-level error details (not just generic 400).\n  - Valid payload persists and remains readable by GET /api/admin/mega-menu.\n- Storefront parity\n  - Public navbar category panel reflects backend-updated mega menu without manual localStorage intervention.\n  - Hidden categories/links remain excluded in shopper view.\n- Regression safety\n  - Existing mega-menu integration tests remain green.\n  - New tests cover at least one invalid payload case and one end-to-end parity check (admin save -> public read/render path).\n\n## Proof Path\n### Manual proof\n1. Login as admin, open /admin/mega-menu.\n2. Submit an invalid payload case (for example empty title or malformed link target), confirm clear validation error and no save.\n3. Submit a valid change (rename one category and add one valid link), confirm success.\n4. Open public homepage in a separate clean session, open Shop by Category, verify updated category/link appears.\n5. Call GET /api/categories and verify returned menu/categories match the change.\n6. Confirm audit endpoint shows the save event in /api/admin/mega-menu/audit.\n\n### Automated proof\n1. Backend:\n   - Run existing + new mega-menu integration tests from backend/tests/integration/megaMenuRoutes.test.js.\n   - Expected: all pass; includes new 422 validation assertions.\n2. Frontend:\n   - Add/extend navbar test coverage (existing pattern in frontend/src/__tests__/unit/components/MerkatoNavbar.vendorSearch.test.js) to assert server-backed category rendering path.\n   - Expected: updated menu values are rendered from API response and fallback behavior remains stable.\n

## PASS Evidence
- PASS evidence permalink: https://github.com/asetolessa711/Merkato/issues/36#issuecomment-4186703361