### PR TITLE
TRAN — Order mirror runtime proof and verification (Mongo-canonical → PostgreSQL transition)

### DIFF
--- a/backend/prisma/migrations/20260406173001_order_mirror_phase2_observability/migration.sql
+++ b/backend/prisma/migrations/20260406173001_order_mirror_phase2_observability/migration.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "OrderMirror"
+  ADD COLUMN "vendorCount" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "itemCount" INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN "invoiceCount" INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE "OrderVendorMirror"
+  ADD COLUMN "vendorName" TEXT,
+  ADD COLUMN "vendorEmail" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -17,6 +17,9 @@ model OrderMirror {
   total              Decimal            @db.Decimal(14, 2)
   totalAfterDiscount Decimal            @db.Decimal(14, 2)
   discount           Decimal            @db.Decimal(14, 2)
+  vendorCount        Int                @default(0)
+  itemCount          Int                @default(0)
+  invoiceCount       Int                @default(0)
   promoMongoId       String?
   shippingAddressJson Json?
   deliveryOptionJson  Json?
@@ -35,6 +38,8 @@ model OrderVendorMirror {
   orderMirrorId     BigInt
   orderMirror       OrderMirror            @relation(fields: [orderMirrorId], references: [id], onDelete: Cascade)
   vendorMongoId     String
+  vendorName        String?
+  vendorEmail       String?
   invoiceMongoId    String?
   subtotal          Decimal               @db.Decimal(14, 2)
   discount          Decimal               @db.Decimal(14, 2)

--- a/backend/routes/orderRoutes.js
+++ b/backend/routes/orderRoutes.js
@@ -326,6 +326,10 @@ router.post('/', optionalAuth, async (req, res) => {
     });
     if (mirrorResult.status === 'failed') {
       console.warn(`[orders] Postgres mirror write failed for ${String(savedOrder._id)}: ${mirrorResult.error}`);
+    } else if (Array.isArray(mirrorResult.discrepancies) && mirrorResult.discrepancies.length > 0) {
+      console.warn(
+        `[orders] Postgres mirror verification mismatch for ${String(savedOrder._id)}: ${mirrorResult.discrepancies.join(', ')}`
+      );
     }
 
     res.status(201).json({

--- a/backend/scripts/postgres/checkOrderMirror.js
+++ b/backend/scripts/postgres/checkOrderMirror.js
@@ -1,6 +1,14 @@
 #!/usr/bin/env node
 
+const mongoose = require("mongoose");
+
 const { getPrismaClient, disconnectPrismaClient } = require("../../prisma/client");
+const Order = require("../../models/Order");
+const {
+  buildMirrorSummary,
+  compareMirrorSummary,
+  summarizeMirroredOrder,
+} = require("../../services/orderPostgresMirror");
 
 async function main() {
   const orderId = process.argv[2] || process.env.MONGO_ORDER_ID;
@@ -11,6 +19,24 @@ async function main() {
   }
 
   const prisma = getPrismaClient();
+  const mongoUri = process.env.MONGO_URI || process.env.MONGO_URI_FALLBACK;
+  if (!mongoUri) {
+    console.error("MONGO_URI or MONGO_URI_FALLBACK is required for mirror comparison");
+    process.exitCode = 3;
+    return;
+  }
+
+  await mongoose.connect(mongoUri, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  });
+
+  const sourceOrder = await Order.findById(orderId).lean();
+  if (!sourceOrder) {
+    console.error(`[pg-mirror-check] No Mongo order found for ${orderId}`);
+    process.exitCode = 4;
+    return;
+  }
 
   const mirrored = await prisma.orderMirror.findUnique({
     where: { mongoId: String(orderId) },
@@ -29,13 +55,24 @@ async function main() {
     return;
   }
 
+  const sourceSummary = buildMirrorSummary(sourceOrder, sourceOrder.vendors || []);
+  const mirroredSummary = summarizeMirroredOrder(mirrored);
+  const discrepancies = compareMirrorSummary(sourceSummary, mirroredSummary);
+  const richShape = {
+    vendorNamesPresent: mirrored.vendors.every((vendor) => Boolean(vendor.vendorName)),
+    vendorEmailsPresent: mirrored.vendors.every((vendor) => Boolean(vendor.vendorEmail)),
+    invoiceLinksPresent: mirrored.vendors.every((vendor) => Boolean(vendor.invoiceMongoId)),
+    itemPricingPresent: mirrored.vendors.every((vendor) =>
+      vendor.items.every((item) => item.name && item.price !== null && item.subtotal !== null && item.tax !== null)
+    ),
+  };
+
   const summary = {
     mongoId: mirrored.mongoId,
-    buyerMongoId: mirrored.buyerMongoId,
-    status: mirrored.status,
-    total: mirrored.total,
-    vendorCount: mirrored.vendors.length,
-    itemCount: mirrored.vendors.reduce((acc, vendor) => acc + vendor.items.length, 0),
+    sourceSummary,
+    mirroredSummary,
+    discrepancies,
+    richShape,
     mirroredAt: mirrored.mirroredAt,
   };
 
@@ -48,5 +85,8 @@ main()
     process.exitCode = 1;
   })
   .finally(async () => {
+    if (mongoose.connection && mongoose.connection.readyState !== 0) {
+      await mongoose.disconnect();
+    }
     await disconnectPrismaClient();
   });

--- a/backend/scripts/postgres/runtimeProofOrderMirror.js
+++ b/backend/scripts/postgres/runtimeProofOrderMirror.js
@@ -10,6 +10,7 @@ const Product = require("../../models/Product");
 const User = require("../../models/User");
 const Invoice = require("../../models/Invoice");
 const { getPrismaClient, disconnectPrismaClient } = require("../../prisma/client");
+const { summarizeMirroredOrder } = require("../../services/orderPostgresMirror");
 
 function rid(prefix) {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -113,6 +114,16 @@ async function run() {
     0
   );
   assert.equal(mirroredItemCount, mongoItemCount, "Mirrored item count mismatch");
+  assert.equal(mirrored.invoiceCount, res.body.invoices.length, "Mirrored invoice count mismatch");
+  assert.ok(mirrored.vendors.every((vendor) => vendor.vendorName), "Vendor names should be mirrored");
+  assert.ok(mirrored.vendors.every((vendor) => vendor.vendorEmail), "Vendor emails should be mirrored");
+  assert.ok(mirrored.vendors.every((vendor) => vendor.invoiceMongoId), "Invoice links should be mirrored");
+  assert.ok(
+    mirrored.vendors.every((vendor) =>
+      vendor.items.every((item) => item.name && item.price !== null && item.subtotal !== null && item.tax !== null)
+    ),
+    "Item pricing fields should be mirrored"
+  );
 
   const responseInvariant = {
     success: res.body.success,
@@ -128,8 +139,7 @@ async function run() {
         orderId: createdOrderId,
         responseInvariant,
         mongoOrderStatus: mongoOrder.status,
-        mirroredVendorCount: mirrored.vendors.length,
-        mirroredItemCount,
+        mirroredSummary: summarizeMirroredOrder(mirrored),
       },
       null,
       2

--- a/backend/services/orderPostgresMirror.js
+++ b/backend/services/orderPostgresMirror.js
@@ -53,6 +53,8 @@ function buildVendorRows(vendors) {
 
     return {
       vendorMongoId: vendor.vendorId ? String(vendor.vendorId) : "",
+      vendorName: vendor.vendorName || null,
+      vendorEmail: vendor.vendorEmail || null,
       invoiceMongoId: vendor.invoiceId ? String(vendor.invoiceId) : null,
       subtotal: toMoney(vendor.subtotal),
       discount: toMoney(vendor.discount),
@@ -82,6 +84,84 @@ function buildVendorRows(vendors) {
   });
 }
 
+function buildMirrorSummary(order, vendors) {
+  const normalizedVendors = Array.isArray(vendors) ? vendors : [];
+  const itemCount = normalizedVendors.reduce((sum, vendor) => {
+    const products = Array.isArray(vendor.products) ? vendor.products : [];
+    return sum + products.length;
+  }, 0);
+  const invoiceCount = normalizedVendors.filter((vendor) => Boolean(vendor.invoiceId)).length;
+
+  return {
+    orderMongoId: order && order._id ? String(order._id) : null,
+    total: toMoney(order && order.total),
+    totalAfterDiscount: toMoney(order && order.totalAfterDiscount),
+    discount: toMoney(order && order.discount),
+    vendorCount: normalizedVendors.length,
+    itemCount,
+    invoiceCount,
+  };
+}
+
+function summarizeMirroredOrder(mirroredOrder) {
+  const vendors = Array.isArray(mirroredOrder && mirroredOrder.vendors) ? mirroredOrder.vendors : [];
+  return {
+    orderMongoId: mirroredOrder && mirroredOrder.mongoId ? String(mirroredOrder.mongoId) : null,
+    total: toMoney(mirroredOrder && mirroredOrder.total),
+    totalAfterDiscount: toMoney(mirroredOrder && mirroredOrder.totalAfterDiscount),
+    discount: toMoney(mirroredOrder && mirroredOrder.discount),
+    vendorCount: Number(mirroredOrder && mirroredOrder.vendorCount) || vendors.length,
+    itemCount:
+      Number(mirroredOrder && mirroredOrder.itemCount) ||
+      vendors.reduce((sum, vendor) => sum + ((vendor.items || []).length), 0),
+    invoiceCount:
+      Number(mirroredOrder && mirroredOrder.invoiceCount) ||
+      vendors.filter((vendor) => Boolean(vendor.invoiceMongoId)).length,
+  };
+}
+
+function compareMirrorSummary(sourceSummary, mirroredSummary) {
+  const discrepancies = [];
+  const keys = ["total", "totalAfterDiscount", "discount", "vendorCount", "itemCount", "invoiceCount"];
+
+  keys.forEach((key) => {
+    if (String(sourceSummary[key]) !== String(mirroredSummary[key])) {
+      discrepancies.push(`${key}:${sourceSummary[key]}->${mirroredSummary[key]}`);
+    }
+  });
+
+  return discrepancies;
+}
+
+function buildMirrorPayload(order, vendors) {
+  const sourceSummary = buildMirrorSummary(order, vendors);
+
+  return {
+    sourceSummary,
+    data: {
+      buyerMongoId: order.buyer ? String(order.buyer) : "",
+      status: order.status || "pending",
+      currency: order.currency || "USD",
+      paymentMethod: order.paymentMethod || "cod",
+      total: sourceSummary.total,
+      totalAfterDiscount: sourceSummary.totalAfterDiscount,
+      discount: sourceSummary.discount,
+      vendorCount: sourceSummary.vendorCount,
+      itemCount: sourceSummary.itemCount,
+      invoiceCount: sourceSummary.invoiceCount,
+      promoMongoId: order.promoCode ? String(order.promoCode) : null,
+      shippingAddressJson: asJsonOrNull(order.shippingAddress),
+      deliveryOptionJson: asJsonOrNull(order.deliveryOption),
+      orderDate: toDate(order.orderDate),
+      sourceCreatedAt: toDate(order.createdAt),
+      sourceUpdatedAt: toDate(order.updatedAt),
+      vendors: {
+        create: buildVendorRows(vendors),
+      },
+    },
+  };
+}
+
 async function mirrorOrderCreationToPostgres({ order, vendors }) {
   const mode = resolveOrdersPgMirrorMode();
   if (mode === "off") {
@@ -94,44 +174,57 @@ async function mirrorOrderCreationToPostgres({ order, vendors }) {
 
   const orderMongoId = String(order._id);
   const prisma = getPrismaClient();
+  const { data, sourceSummary } = buildMirrorPayload(order, vendors);
 
   try {
     const existing = await prisma.orderMirror.findUnique({
       where: { mongoId: orderMongoId },
-      select: { id: true },
-    });
-
-    if (existing) {
-      return { status: "skipped", reason: "already-mirrored", orderMongoId };
-    }
-
-    await prisma.orderMirror.create({
-      data: {
-        mongoId: orderMongoId,
-        buyerMongoId: order.buyer ? String(order.buyer) : "",
-        status: order.status || "pending",
-        currency: order.currency || "USD",
-        paymentMethod: order.paymentMethod || "cod",
-        total: toMoney(order.total),
-        totalAfterDiscount: toMoney(order.totalAfterDiscount),
-        discount: toMoney(order.discount),
-        promoMongoId: order.promoCode ? String(order.promoCode) : null,
-        shippingAddressJson: asJsonOrNull(order.shippingAddress),
-        deliveryOptionJson: asJsonOrNull(order.deliveryOption),
-        orderDate: toDate(order.orderDate),
-        sourceCreatedAt: toDate(order.createdAt),
-        sourceUpdatedAt: toDate(order.updatedAt),
+      include: {
         vendors: {
-          create: buildVendorRows(vendors),
+          include: {
+            items: true,
+          },
         },
       },
     });
 
+    const mirrored = await prisma.orderMirror.upsert({
+      where: { mongoId: orderMongoId },
+      create: {
+        mongoId: orderMongoId,
+        ...data,
+      },
+      update: {
+        ...data,
+        vendors: {
+          deleteMany: {},
+          create: buildVendorRows(vendors),
+        },
+      },
+      include: {
+        vendors: {
+          include: {
+            items: true,
+          },
+        },
+      },
+    });
+
+    const mirroredSummary = summarizeMirroredOrder(mirrored);
+    const discrepancies = compareMirrorSummary(sourceSummary, mirroredSummary);
+
     if (String(process.env.ORDERS_PG_MIRROR_LOG_SUCCESS || "").toLowerCase() === "true") {
-      console.log(`[orders-postgres-mirror] Mirrored order ${orderMongoId} to Postgres.`);
+      console.log(
+        `[orders-postgres-mirror] ${existing ? "Updated" : "Mirrored"} order ${orderMongoId} to Postgres.`
+      );
     }
 
-    return { status: "ok", orderMongoId };
+    return {
+      status: existing ? "updated" : "ok",
+      orderMongoId,
+      summary: sourceSummary,
+      discrepancies,
+    };
   } catch (error) {
     const message = error && error.message ? error.message : String(error);
     console.warn(`[orders-postgres-mirror] Failed to mirror order ${orderMongoId}: ${message}`);
@@ -140,6 +233,11 @@ async function mirrorOrderCreationToPostgres({ order, vendors }) {
 }
 
 module.exports = {
+  buildMirrorPayload,
+  buildMirrorSummary,
+  buildVendorRows,
+  compareMirrorSummary,
   mirrorOrderCreationToPostgres,
   resolveOrdersPgMirrorMode,
+  summarizeMirroredOrder,
 };

--- a/backend/tests/unit/services/orderPostgresMirror.test.js
+++ b/backend/tests/unit/services/orderPostgresMirror.test.js
@@ -1,0 +1,140 @@
+const {
+  buildMirrorSummary,
+  buildVendorRows,
+  compareMirrorSummary,
+  resolveOrdersPgMirrorMode,
+  summarizeMirroredOrder,
+} = require("../../../services/orderPostgresMirror");
+
+describe("orderPostgresMirror", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  test("falls back to off when mirror mode is invalid", () => {
+    process.env.ORDERS_PG_MIRROR_MODE = "unsupported";
+
+    expect(resolveOrdersPgMirrorMode()).toBe("off");
+  });
+
+  test("builds vendor rows with richer mirrored shape", () => {
+    const rows = buildVendorRows([
+      {
+        vendorId: "vendor-1",
+        vendorName: "Vendor One",
+        vendorEmail: "vendor@example.com",
+        invoiceId: "invoice-1",
+        subtotal: 25,
+        discount: 1,
+        tax: 3.75,
+        shipping: 5,
+        total: 32.75,
+        commissionRate: 0.1,
+        commissionAmount: 2.5,
+        netEarnings: 30.25,
+        currency: "USD",
+        status: "pending",
+        products: [
+          {
+            product: "product-1",
+            name: "Mirror Product",
+            quantity: 2,
+            price: 12.5,
+            subtotal: 25,
+            tax: 3.75,
+          },
+        ],
+      },
+    ]);
+
+    expect(rows[0]).toMatchObject({
+      vendorMongoId: "vendor-1",
+      vendorName: "Vendor One",
+      vendorEmail: "vendor@example.com",
+      invoiceMongoId: "invoice-1",
+    });
+    expect(rows[0].items.create[0]).toMatchObject({
+      productMongoId: "product-1",
+      name: "Mirror Product",
+      quantity: 2,
+      price: "12.50",
+      subtotal: "25.00",
+      tax: "3.75",
+    });
+  });
+
+  test("summarizes mirror counts for observability", () => {
+    const sourceSummary = buildMirrorSummary(
+      { _id: "order-1", total: 42.75, totalAfterDiscount: 40.25, discount: 2.5 },
+      [
+        { invoiceId: "invoice-1", products: [{}, {}] },
+        { invoiceId: "invoice-2", products: [{}] },
+      ]
+    );
+
+    expect(sourceSummary).toMatchObject({
+      orderMongoId: "order-1",
+      total: "42.75",
+      totalAfterDiscount: "40.25",
+      discount: "2.50",
+      vendorCount: 2,
+      itemCount: 3,
+      invoiceCount: 2,
+    });
+  });
+
+  test("reports summary discrepancies explicitly", () => {
+    const discrepancies = compareMirrorSummary(
+      {
+        total: "42.75",
+        totalAfterDiscount: "40.25",
+        discount: "2.50",
+        vendorCount: 2,
+        itemCount: 3,
+        invoiceCount: 2,
+      },
+      {
+        total: "42.75",
+        totalAfterDiscount: "39.00",
+        discount: "2.50",
+        vendorCount: 1,
+        itemCount: 2,
+        invoiceCount: 1,
+      }
+    );
+
+    expect(discrepancies).toEqual(
+      expect.arrayContaining([
+        "totalAfterDiscount:40.25->39.00",
+        "vendorCount:2->1",
+        "itemCount:3->2",
+        "invoiceCount:2->1",
+      ])
+    );
+  });
+
+  test("summarizes mirrored rows using stored observability counts", () => {
+    const summary = summarizeMirroredOrder({
+      mongoId: "order-2",
+      total: "42.75",
+      totalAfterDiscount: "40.25",
+      discount: "2.50",
+      vendorCount: 2,
+      itemCount: 3,
+      invoiceCount: 2,
+      vendors: [
+        { invoiceMongoId: "invoice-1", items: [{}, {}] },
+        { invoiceMongoId: "invoice-2", items: [{}] },
+      ],
+    });
+
+    expect(summary).toMatchObject({
+      orderMongoId: "order-2",
+      vendorCount: 2,
+      itemCount: 3,
+      invoiceCount: 2,
+    });
+  });
+});

--- a/docs/issues/tran-order-mirror-runtime-proof-verification.md
+++ b/docs/issues/tran-order-mirror-runtime-proof-verification.md
@@ -1,0 +1,29 @@
+# TRAN — Order mirror runtime proof and verification (Mongo-canonical -> PostgreSQL transition)
+
+## Short Findings Summary (Abandoned Attempt)
+- PR #62 became empty versus current main and stopped being a trustworthy execution vehicle.
+- Identifiable unmerged Phase 2 work existed only in dirty local state and branch-local continuity, not as a clean governed PR diff.
+- Canonical proof workflow attachment can fail to appear when the PR diff is empty and path filters are used.
+
+## Scope Lock
+
+### NEW canonical path
+- PostgreSQL mirror hardening and runtime proof for order creation, with governance evidence produced via CI.
+- Canonical closure evidence comes from CI-only runtime proof workflow and required checks.
+
+### LEGACY path still present
+- MongoDB remains canonical for order creation while transition is in progress.
+- Existing Mongo order write/read behavior remains unchanged in this slice.
+
+### TRANSITIONAL bridge path
+- Mirror-only PostgreSQL writes from the Mongo-canonical order creation flow.
+- Verification/observability compares Mongo source shape to mirrored PostgreSQL shape.
+- Mongo touches are allowed only when directly enabling PostgreSQL transition proof/verification.
+
+### Untouched surfaces
+- No read-path cutover.
+- No backfill.
+- No invoice/returns migration.
+- No broader identity/product migration.
+- No external API behavior changes.
+- No Mongo modernization/stabilization work as destination progress.


### PR DESCRIPTION
Closes #66

Execution vehicle
- Fresh clean restart branch from current main.
- Draft until post-proof closure evidence is complete.

Scope lock source
- docs/issues/tran-order-mirror-runtime-proof-verification.md

Status system
- NEW canonical path: PostgreSQL mirror runtime proof/verification.
- LEGACY path still present: Mongo canonical order creation.
- TRANSITIONAL bridge path: mirror-only write + verification.
- Untouched surfaces: no cutover/backfill/invoice-returns/identity-product migration/API behavior changes.