### PR TITLE
NEW — Identity and external-ID foundation (canonical model baseline)

### DIFF
--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -1,5 +1,10 @@
 const mongoose = require('mongoose');
 const bcrypt = require('bcryptjs');
+const {
+  generateExternalId,
+  isLikelyMongoObjectId,
+  isValidExternalId,
+} = require('../utils/externalId');
 
 const userSchema = new mongoose.Schema(
   {
@@ -11,6 +16,18 @@ const userSchema = new mongoose.Schema(
       type: String,
       unique: true,
       required: true
+    },
+    externalId: {
+      type: String,
+      unique: true,
+      sparse: true,
+      immutable: true,
+      lowercase: true,
+      trim: true,
+      validate: {
+        validator: (value) => !value || isValidExternalId(value),
+        message: 'Invalid canonical external ID format',
+      },
     },
     password: {
       type: String,
@@ -76,6 +93,16 @@ const userSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
+userSchema.pre('validate', function (next) {
+  if (this.isNew && !this.externalId) {
+    this.externalId = generateExternalId();
+    if (String(process.env.IDENTITY_EXTERNAL_ID_LOG || '').toLowerCase() === 'true') {
+      console.info(`[identity-foundation] Assigned externalId=${this.externalId} for user email=${this.email}`);
+    }
+  }
+  next();
+});
+
 // Hash password before save
 userSchema.pre('save', async function (next) {
   if (!this.isModified('password')) return next();
@@ -91,6 +118,26 @@ userSchema.pre('save', async function (next) {
 // Compare password
 userSchema.methods.matchPassword = async function (enteredPassword) {
   return await bcrypt.compare(enteredPassword, this.password);
+};
+
+userSchema.methods.getCanonicalIdentityKey = function () {
+  return this.externalId || String(this._id);
+};
+
+userSchema.statics.isCanonicalExternalId = function (value) {
+  return isValidExternalId(value);
+};
+
+userSchema.statics.findByCanonicalIdentity = async function (identityKey, projection = null, options = {}) {
+  const normalized = String(identityKey || '').trim().toLowerCase();
+  if (!normalized) return null;
+  if (isValidExternalId(normalized)) {
+    return this.findOne({ externalId: normalized }, projection, options);
+  }
+  if (isLikelyMongoObjectId(normalized)) {
+    return this.findById(normalized, projection, options);
+  }
+  return null;
 };
 
 module.exports = mongoose.model('User', userSchema);

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -93,14 +93,45 @@ const userSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
-userSchema.pre('validate', function (next) {
-  if (this.isNew && !this.externalId) {
-    this.externalId = generateExternalId();
-    if (String(process.env.IDENTITY_EXTERNAL_ID_LOG || '').toLowerCase() === 'true') {
-      console.info(`[identity-foundation] Assigned externalId=${this.externalId} for user email=${this.email}`);
+userSchema.pre('validate', async function (next) {
+  try {
+    if (this.isNew && !this.externalId) {
+      this.externalId = generateExternalId();
+      if (String(process.env.IDENTITY_EXTERNAL_ID_LOG || '').toLowerCase() === 'true') {
+        console.info(`[identity-foundation] Assigned externalId=${this.externalId} for user email=${this.email}`);
+      }
     }
+
+    if (!this.isNew && this.isModified('externalId')) {
+      this.invalidate('externalId', 'externalId is immutable once assigned');
+      return next();
+    }
+
+    const needsUniquenessCheck = this.externalId && (this.isNew || this.isModified('externalId'));
+    if (!needsUniquenessCheck) {
+      return next();
+    }
+
+    const allowCheckWhileDisconnected =
+      String(process.env.IDENTITY_EXTERNAL_ID_TEST_UNIQUENESS || '').toLowerCase() === 'true';
+    const hasLiveDbConnection = this.constructor.db && this.constructor.db.readyState === 1;
+    if (!hasLiveDbConnection && !allowCheckWhileDisconnected) {
+      return next();
+    }
+
+    const duplicate = await this.constructor.exists({
+      externalId: this.externalId,
+      _id: { $ne: this._id },
+    });
+
+    if (duplicate) {
+      this.invalidate('externalId', 'externalId is already in use');
+    }
+
+    next();
+  } catch (err) {
+    next(err);
   }
-  next();
 });
 
 // Hash password before save

--- a/backend/tests/unit/models/externalId.foundation.test.js
+++ b/backend/tests/unit/models/externalId.foundation.test.js
@@ -1,0 +1,59 @@
+const mongoose = require('mongoose');
+const User = require('../../../models/User');
+const {
+  generateExternalId,
+  isLikelyMongoObjectId,
+  isValidExternalId,
+} = require('../../../utils/externalId');
+
+describe('NEW identity external-ID foundation', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('generates a valid canonical externalId format', () => {
+    const externalId = generateExternalId();
+    expect(isValidExternalId(externalId)).toBe(true);
+    expect(externalId.startsWith('uid_')).toBe(true);
+  });
+
+  test('recognizes legacy mongo object id shape', () => {
+    const mongoId = new mongoose.Types.ObjectId().toString();
+    expect(isLikelyMongoObjectId(mongoId)).toBe(true);
+    expect(isLikelyMongoObjectId('not-a-mongo-id')).toBe(false);
+  });
+
+  test('assigns externalId during validation for new user documents', async () => {
+    const user = new User({
+      name: 'Identity Foundation User',
+      email: `new-foundation-${Date.now()}@example.com`,
+      password: 'Password123!',
+      country: 'ET',
+    });
+
+    await user.validate();
+
+    expect(user.externalId).toBeTruthy();
+    expect(isValidExternalId(user.externalId)).toBe(true);
+    expect(user.getCanonicalIdentityKey()).toBe(user.externalId);
+  });
+
+  test('findByCanonicalIdentity prefers externalId and falls back to legacy _id', async () => {
+    const externalId = generateExternalId();
+    const mongoId = new mongoose.Types.ObjectId().toString();
+
+    const findOneSpy = jest.spyOn(User, 'findOne').mockReturnValue('external-query');
+    const findByIdSpy = jest.spyOn(User, 'findById').mockReturnValue('legacy-query');
+
+    const byExternal = await User.findByCanonicalIdentity(externalId);
+    expect(byExternal).toBe('external-query');
+    expect(findOneSpy).toHaveBeenCalledWith({ externalId }, null, {});
+
+    const byLegacy = await User.findByCanonicalIdentity(mongoId);
+    expect(byLegacy).toBe('legacy-query');
+    expect(findByIdSpy).toHaveBeenCalledWith(mongoId, null, {});
+
+    const invalid = await User.findByCanonicalIdentity('invalid-value');
+    expect(invalid).toBeNull();
+  });
+});

--- a/backend/tests/unit/models/externalId.foundation.test.js
+++ b/backend/tests/unit/models/externalId.foundation.test.js
@@ -7,7 +7,10 @@ const {
 } = require('../../../utils/externalId');
 
 describe('NEW identity external-ID foundation', () => {
+  const originalEnv = { ...process.env };
+
   afterEach(() => {
+    process.env = { ...originalEnv };
     jest.restoreAllMocks();
   });
 
@@ -55,5 +58,51 @@ describe('NEW identity external-ID foundation', () => {
 
     const invalid = await User.findByCanonicalIdentity('invalid-value');
     expect(invalid).toBeNull();
+  });
+
+  test('rejects duplicate externalId during validation (uniqueness behavior)', async () => {
+    process.env.IDENTITY_EXTERNAL_ID_TEST_UNIQUENESS = 'true';
+
+    const externalId = generateExternalId();
+    const existsSpy = jest.spyOn(User, 'exists').mockResolvedValue({ _id: new mongoose.Types.ObjectId() });
+
+    const user = new User({
+      name: 'Duplicate ExternalId User',
+      email: `duplicate-external-${Date.now()}@example.com`,
+      password: 'Password123!',
+      country: 'ET',
+      externalId,
+    });
+
+    await expect(user.validate()).rejects.toThrow(mongoose.Error.ValidationError);
+    await user.validate().catch((err) => {
+      expect(err.errors.externalId.message).toMatch(/already in use/i);
+    });
+
+    expect(existsSpy).toHaveBeenCalledWith({
+      externalId,
+      _id: { $ne: user._id },
+    });
+  });
+
+  test('rejects attempted externalId mutation after initial assignment (immutability behavior)', async () => {
+    process.env.IDENTITY_EXTERNAL_ID_TEST_UNIQUENESS = 'true';
+    jest.spyOn(User, 'exists').mockResolvedValue(null);
+
+    const user = new User({
+      name: 'Immutable ExternalId User',
+      email: `immutable-external-${Date.now()}@example.com`,
+      password: 'Password123!',
+      country: 'ET',
+    });
+    await user.validate();
+
+    user.isNew = false;
+    user.externalId = generateExternalId();
+
+    await expect(user.validate()).rejects.toThrow(mongoose.Error.ValidationError);
+    await user.validate().catch((err) => {
+      expect(err.errors.externalId.message).toMatch(/immutable/i);
+    });
   });
 });

--- a/backend/utils/externalId.js
+++ b/backend/utils/externalId.js
@@ -1,0 +1,26 @@
+const crypto = require('crypto');
+
+const EXTERNAL_ID_PREFIX = 'uid';
+const EXTERNAL_ID_BODY_LENGTH = 20;
+const EXTERNAL_ID_PATTERN = new RegExp(`^${EXTERNAL_ID_PREFIX}_[a-f0-9]{${EXTERNAL_ID_BODY_LENGTH}}$`);
+const LEGACY_MONGO_ID_PATTERN = /^[a-f0-9]{24}$/;
+
+function generateExternalId() {
+  return `${EXTERNAL_ID_PREFIX}_${crypto.randomBytes(10).toString('hex')}`;
+}
+
+function isValidExternalId(value) {
+  if (!value) return false;
+  return EXTERNAL_ID_PATTERN.test(String(value).trim().toLowerCase());
+}
+
+function isLikelyMongoObjectId(value) {
+  if (!value) return false;
+  return LEGACY_MONGO_ID_PATTERN.test(String(value).trim().toLowerCase());
+}
+
+module.exports = {
+  generateExternalId,
+  isLikelyMongoObjectId,
+  isValidExternalId,
+};

--- a/docs/issues/new-identity-external-id-foundation.md
+++ b/docs/issues/new-identity-external-id-foundation.md
@@ -1,0 +1,40 @@
+# NEW — Identity and external-ID foundation (canonical model baseline)
+
+## Purpose
+- Establish the first canonical NEW slice for identity and external IDs with clear governance boundaries.
+- Define stable identity primitives required by future migration slices without changing external behavior yet.
+
+## Scope lock (strict)
+
+### NEW canonical path
+- Introduce canonical external-ID foundation primitives and invariants for core identity entities.
+- Define normalized identity key semantics (generation/format/uniqueness/immutability policy).
+- Add foundational persistence/model hooks needed to store, validate, and safely read canonical external IDs without changing external runtime behavior.
+- Add focused validation/tests for ID shape, uniqueness, referential linkage, and backward-safe reads.
+- Add observability for ID assignment/validation outcomes (non-invasive, internal only).
+
+### LEGACY path still present
+- Existing Mongo `_id`-based operational behavior remains active and canonical for runtime behavior in this slice.
+- Existing auth/session/account flows continue unchanged.
+
+### TRANSITIONAL bridge path
+- Bridge mapping between legacy identifiers and canonical external IDs where required for internal consistency.
+- Transitional reads/writes are internal-only and must not alter API response contracts.
+- No cutover: bridge enables later migration slices, not destination-state behavior changes now.
+
+### Untouched surfaces
+- No auth UX redesign.
+- No permission/role model redesign.
+- No checkout/order flow behavior changes.
+- No read-path cutover.
+- No backfill execution in this slice.
+- No invoice/returns migration.
+- No product-domain migration.
+- No external API contract changes.
+- No client-visible identifier format changes.
+
+## Governance notes
+- Keep PR in Draft until foundation validation evidence is complete.
+- Require explicit NEW / LEGACY / TRANSITIONAL labels in issue/PR body.
+- Any Mongo touch must be transition-enabling only for canonical ID foundation, not Mongo modernization.
+- No parked or local-only continuity may be treated as source of truth; remote issue, branch, and PR state are canonical.


### PR DESCRIPTION
Closes #68

Execution start
- Clean branch from current main: new-identity-external-id-foundation
- Draft until foundation validation evidence is complete.

Scope lock source
- docs/issues/new-identity-external-id-foundation.md

NEW canonical path
- Introduce canonical external-ID foundation primitives and invariants for core identity entities.
- Define normalized identity key semantics (generation/format/uniqueness/immutability policy).
- Add foundational persistence/model hooks needed to store, validate, and safely read canonical external IDs without changing external runtime behavior.
- Add focused validation/tests for ID shape, uniqueness, referential linkage, and backward-safe reads.
- Add observability for ID assignment/validation outcomes (non-invasive, internal only).

LEGACY path still present
- Existing Mongo `_id`-based operational behavior remains active and canonical for runtime behavior in this slice.
- Existing auth/session/account flows continue unchanged.

TRANSITIONAL bridge path
- Bridge mapping between legacy identifiers and canonical external IDs where required for internal consistency.
- Transitional reads/writes are internal-only and must not alter API response contracts.
- No cutover: bridge enables later migration slices, not destination-state behavior changes now.

Untouched surfaces
- No auth UX redesign.
- No permission/role model redesign.
- No checkout/order flow behavior changes.
- No read-path cutover.
- No backfill execution in this slice.
- No invoice/returns migration.
- No product-domain migration.
- No external API contract changes.
- No client-visible identifier format changes.

Governance notes
- Require explicit NEW / LEGACY / TRANSITIONAL labels in issue/PR body.
- Any Mongo touch must be transition-enabling only for canonical ID foundation, not Mongo modernization.
- No parked or local-only continuity may be treated as source of truth; remote issue, branch, and PR state are canonical.
