### PR TITLE
NEW — Product and vendor foundation (canonical model baseline)

### DIFF
--- a/backend/models/Product.js
+++ b/backend/models/Product.js
@@ -1,7 +1,24 @@
 const mongoose = require('mongoose');
+const {
+  generateProductExternalId,
+  isLikelyMongoObjectId,
+  isValidProductExternalId,
+} = require('../utils/externalId');
 
 const productSchema = new mongoose.Schema(
   {
+    externalId: {
+      type: String,
+      unique: true,
+      sparse: true,
+      immutable: true,
+      lowercase: true,
+      trim: true,
+      validate: {
+        validator: (value) => !value || isValidProductExternalId(value),
+        message: 'Invalid canonical product external ID format',
+      },
+    },
     name: { type: String, required: true },
     description: { type: String },
     price: { type: Number, required: true },
@@ -47,5 +64,66 @@ const productSchema = new mongoose.Schema(
   },
   { timestamps: true }
 );
+
+productSchema.pre('validate', async function (next) {
+  try {
+    if (this.isNew && !this.externalId) {
+      this.externalId = generateProductExternalId();
+      if (String(process.env.PRODUCT_EXTERNAL_ID_LOG || '').toLowerCase() === 'true') {
+        console.info(`[product-foundation] Assigned externalId=${this.externalId} for product=${this.name}`);
+      }
+    }
+
+    if (!this.isNew && this.isModified('externalId')) {
+      this.invalidate('externalId', 'externalId is immutable once assigned');
+      return next();
+    }
+
+    const needsUniquenessCheck = this.externalId && (this.isNew || this.isModified('externalId'));
+    if (!needsUniquenessCheck) {
+      return next();
+    }
+
+    const allowCheckWhileDisconnected =
+      String(process.env.PRODUCT_EXTERNAL_ID_TEST_UNIQUENESS || '').toLowerCase() === 'true';
+    const hasLiveDbConnection = this.constructor.db && this.constructor.db.readyState === 1;
+    if (!hasLiveDbConnection && !allowCheckWhileDisconnected) {
+      return next();
+    }
+
+    const duplicate = await this.constructor.exists({
+      externalId: this.externalId,
+      _id: { $ne: this._id },
+    });
+
+    if (duplicate) {
+      this.invalidate('externalId', 'externalId is already in use');
+    }
+
+    next();
+  } catch (err) {
+    next(err);
+  }
+});
+
+productSchema.methods.getCanonicalIdentityKey = function () {
+  return this.externalId || String(this._id);
+};
+
+productSchema.statics.isCanonicalExternalId = function (value) {
+  return isValidProductExternalId(value);
+};
+
+productSchema.statics.findByCanonicalIdentity = async function (identityKey, projection = null, options = {}) {
+  const normalized = String(identityKey || '').trim().toLowerCase();
+  if (!normalized) return null;
+  if (isValidProductExternalId(normalized)) {
+    return this.findOne({ externalId: normalized }, projection, options);
+  }
+  if (isLikelyMongoObjectId(normalized)) {
+    return this.findById(normalized, projection, options);
+  }
+  return null;
+};
 
 module.exports = mongoose.model('Product', productSchema);

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -171,4 +171,26 @@ userSchema.statics.findByCanonicalIdentity = async function (identityKey, projec
   return null;
 };
 
+userSchema.methods.getCanonicalVendorIdentityKey = function () {
+  const roles = Array.isArray(this.roles) ? this.roles : [];
+  if (!roles.includes('vendor')) return null;
+  return this.getCanonicalIdentityKey();
+};
+
+userSchema.statics.findVendorByCanonicalIdentity = async function (
+  identityKey,
+  projection = null,
+  options = {}
+) {
+  const normalized = String(identityKey || '').trim().toLowerCase();
+  if (!normalized) return null;
+  if (isValidExternalId(normalized)) {
+    return this.findOne({ externalId: normalized, roles: 'vendor' }, projection, options);
+  }
+  if (isLikelyMongoObjectId(normalized)) {
+    return this.findOne({ _id: normalized, roles: 'vendor' }, projection, options);
+  }
+  return null;
+};
+
 module.exports = mongoose.model('User', userSchema);

--- a/backend/tests/unit/models/productVendor.foundation.test.js
+++ b/backend/tests/unit/models/productVendor.foundation.test.js
@@ -1,0 +1,152 @@
+const mongoose = require('mongoose');
+const Product = require('../../../models/Product');
+const User = require('../../../models/User');
+const {
+  generateExternalId,
+  generateProductExternalId,
+  generateVendorExternalId,
+  isValidProductExternalId,
+  isValidVendorExternalId,
+} = require('../../../utils/externalId');
+
+describe('NEW product/vendor foundation', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    jest.restoreAllMocks();
+  });
+
+  test('generates valid canonical product and vendor external ID formats', () => {
+    const productExternalId = generateProductExternalId();
+    const vendorExternalId = generateVendorExternalId();
+
+    expect(isValidProductExternalId(productExternalId)).toBe(true);
+    expect(productExternalId.startsWith('pid_')).toBe(true);
+
+    expect(isValidVendorExternalId(vendorExternalId)).toBe(true);
+    expect(vendorExternalId.startsWith('uid_')).toBe(true);
+
+    expect(isValidProductExternalId(vendorExternalId)).toBe(false);
+    expect(isValidVendorExternalId(productExternalId)).toBe(false);
+  });
+
+  test('assigns externalId during validation for new product documents', async () => {
+    const product = new Product({
+      name: `Foundation Product ${Date.now()}`,
+      price: 25,
+      vendor: new mongoose.Types.ObjectId(),
+    });
+
+    await product.validate();
+
+    expect(product.externalId).toBeTruthy();
+    expect(isValidProductExternalId(product.externalId)).toBe(true);
+    expect(product.getCanonicalIdentityKey()).toBe(product.externalId);
+  });
+
+  test('Product.findByCanonicalIdentity prefers externalId and falls back to legacy _id', async () => {
+    const productExternalId = generateProductExternalId();
+    const legacyId = new mongoose.Types.ObjectId().toString();
+
+    const findOneSpy = jest.spyOn(Product, 'findOne').mockReturnValue('product-external-query');
+    const findByIdSpy = jest.spyOn(Product, 'findById').mockReturnValue('product-legacy-query');
+
+    const byExternal = await Product.findByCanonicalIdentity(productExternalId);
+    expect(byExternal).toBe('product-external-query');
+    expect(findOneSpy).toHaveBeenCalledWith({ externalId: productExternalId }, null, {});
+
+    const byLegacy = await Product.findByCanonicalIdentity(legacyId);
+    expect(byLegacy).toBe('product-legacy-query');
+    expect(findByIdSpy).toHaveBeenCalledWith(legacyId, null, {});
+
+    const invalid = await Product.findByCanonicalIdentity('invalid-value');
+    expect(invalid).toBeNull();
+  });
+
+  test('rejects duplicate product externalId during validation (uniqueness behavior)', async () => {
+    process.env.PRODUCT_EXTERNAL_ID_TEST_UNIQUENESS = 'true';
+
+    const externalId = generateProductExternalId();
+    const existsSpy = jest.spyOn(Product, 'exists').mockResolvedValue({ _id: new mongoose.Types.ObjectId() });
+
+    const product = new Product({
+      name: `Duplicate Product ${Date.now()}`,
+      price: 99,
+      vendor: new mongoose.Types.ObjectId(),
+      externalId,
+    });
+
+    await expect(product.validate()).rejects.toThrow(mongoose.Error.ValidationError);
+    await product.validate().catch((err) => {
+      expect(err.errors.externalId.message).toMatch(/already in use/i);
+    });
+
+    expect(existsSpy).toHaveBeenCalledWith({
+      externalId,
+      _id: { $ne: product._id },
+    });
+  });
+
+  test('rejects attempted product externalId mutation after initial assignment (immutability behavior)', async () => {
+    process.env.PRODUCT_EXTERNAL_ID_TEST_UNIQUENESS = 'true';
+    jest.spyOn(Product, 'exists').mockResolvedValue(null);
+
+    const product = new Product({
+      name: `Immutable Product ${Date.now()}`,
+      price: 50,
+      vendor: new mongoose.Types.ObjectId(),
+    });
+    await product.validate();
+
+    product.isNew = false;
+    product.externalId = generateProductExternalId();
+
+    await expect(product.validate()).rejects.toThrow(mongoose.Error.ValidationError);
+    await product.validate().catch((err) => {
+      expect(err.errors.externalId.message).toMatch(/immutable/i);
+    });
+  });
+
+  test('User.findVendorByCanonicalIdentity limits canonical lookup to vendor role', async () => {
+    const vendorExternalId = generateExternalId();
+    const legacyId = new mongoose.Types.ObjectId().toString();
+
+    const findOneSpy = jest.spyOn(User, 'findOne').mockReturnValue('vendor-query');
+
+    const byExternal = await User.findVendorByCanonicalIdentity(vendorExternalId);
+    expect(byExternal).toBe('vendor-query');
+    expect(findOneSpy).toHaveBeenCalledWith({ externalId: vendorExternalId, roles: 'vendor' }, null, {});
+
+    const byLegacy = await User.findVendorByCanonicalIdentity(legacyId);
+    expect(byLegacy).toBe('vendor-query');
+    expect(findOneSpy).toHaveBeenCalledWith({ _id: legacyId, roles: 'vendor' }, null, {});
+
+    const invalid = await User.findVendorByCanonicalIdentity('invalid-value');
+    expect(invalid).toBeNull();
+  });
+
+  test('getCanonicalVendorIdentityKey returns canonical key for vendor users only', () => {
+    const vendorUser = new User({
+      name: 'Vendor Foundation User',
+      email: `vendor-foundation-${Date.now()}@example.com`,
+      password: 'Password123!',
+      country: 'ET',
+      roles: ['vendor'],
+    });
+
+    vendorUser.externalId = generateExternalId();
+    expect(vendorUser.getCanonicalVendorIdentityKey()).toBe(vendorUser.externalId);
+
+    const nonVendorUser = new User({
+      name: 'Customer Foundation User',
+      email: `customer-foundation-${Date.now()}@example.com`,
+      password: 'Password123!',
+      country: 'ET',
+      roles: ['customer'],
+    });
+
+    nonVendorUser.externalId = generateExternalId();
+    expect(nonVendorUser.getCanonicalVendorIdentityKey()).toBeNull();
+  });
+});

--- a/backend/utils/externalId.js
+++ b/backend/utils/externalId.js
@@ -1,17 +1,38 @@
 const crypto = require('crypto');
 
 const EXTERNAL_ID_PREFIX = 'uid';
+const PRODUCT_EXTERNAL_ID_PREFIX = 'pid';
 const EXTERNAL_ID_BODY_LENGTH = 20;
 const EXTERNAL_ID_PATTERN = new RegExp(`^${EXTERNAL_ID_PREFIX}_[a-f0-9]{${EXTERNAL_ID_BODY_LENGTH}}$`);
+const PRODUCT_EXTERNAL_ID_PATTERN = new RegExp(
+  `^${PRODUCT_EXTERNAL_ID_PREFIX}_[a-f0-9]{${EXTERNAL_ID_BODY_LENGTH}}$`
+);
 const LEGACY_MONGO_ID_PATTERN = /^[a-f0-9]{24}$/;
 
 function generateExternalId() {
   return `${EXTERNAL_ID_PREFIX}_${crypto.randomBytes(10).toString('hex')}`;
 }
 
+function generateProductExternalId() {
+  return `${PRODUCT_EXTERNAL_ID_PREFIX}_${crypto.randomBytes(10).toString('hex')}`;
+}
+
+function generateVendorExternalId() {
+  return generateExternalId();
+}
+
 function isValidExternalId(value) {
   if (!value) return false;
   return EXTERNAL_ID_PATTERN.test(String(value).trim().toLowerCase());
+}
+
+function isValidProductExternalId(value) {
+  if (!value) return false;
+  return PRODUCT_EXTERNAL_ID_PATTERN.test(String(value).trim().toLowerCase());
+}
+
+function isValidVendorExternalId(value) {
+  return isValidExternalId(value);
 }
 
 function isLikelyMongoObjectId(value) {
@@ -21,6 +42,10 @@ function isLikelyMongoObjectId(value) {
 
 module.exports = {
   generateExternalId,
+  generateProductExternalId,
+  generateVendorExternalId,
   isLikelyMongoObjectId,
   isValidExternalId,
+  isValidProductExternalId,
+  isValidVendorExternalId,
 };

--- a/docs/issues/new-product-vendor-foundation.md
+++ b/docs/issues/new-product-vendor-foundation.md
@@ -1,0 +1,42 @@
+# Scope Lock — NEW: Product and Vendor Foundation
+
+## Intent
+
+Establish the canonical NEW foundation for product and vendor identity at the model/util layer only.
+This slice is foundation-only and must not open migration, cutover, or broad behavior change work.
+
+## NEW canonical path
+
+* Introduce canonical identity foundation for Product and Vendor entities (NEW-first structure and utilities).
+* Define canonical external identifier shape/validation/generation for Product and Vendor, aligned with the identity foundation pattern already established.
+* Add narrowly scoped model-level guarantees and helper behavior needed to store, validate, and safely read canonical Product and Vendor external identifiers without changing external runtime behavior.
+* Add focused unit tests proving the foundation invariants for Product and Vendor identity fields/utilities.
+
+## LEGACY path still present
+
+* Existing Mongo-backed runtime behavior and legacy identifiers remain authoritative for this slice.
+* Existing read/write behavior that depends on legacy identifiers remains authoritative for this slice.
+* No endpoint contracts or API payload semantics are changed in this slice.
+
+## TRANSITIONAL bridge path, if any
+
+* Optional, minimal bridge only at helper/lookup abstraction level if strictly required to connect NEW foundation with current internal model access.
+* No read cutover.
+* No dual-write introduction.
+* No backfill job or migration orchestration.
+* If no minimal bridge is required during implementation, this section is treated as intentionally empty.
+
+## Untouched surfaces
+
+* No order, checkout, payment, shipment, invoice, returns, or analytics workflow changes.
+* No product catalog behavior changes beyond identity foundation primitives.
+* No vendor onboarding/business-process changes.
+* No UI/E2E scope expansion.
+* No data backfill, no historical rewrite, no operational migration runbook in this slice.
+
+## Hard boundaries
+
+* Keep this slice model/util + focused unit tests only.
+* Do not introduce broad repository-wide refactors.
+* Do not modify external API contracts.
+* Do not start migration execution work; only establish verifiable foundation primitives.


### PR DESCRIPTION
# Scope Lock — NEW: Product and Vendor Foundation

## Intent

Establish the canonical NEW foundation for product and vendor identity at the model/util layer only.
This slice is foundation-only and must not open migration, cutover, or broad behavior change work.

## NEW canonical path

* Introduce canonical identity foundation for Product and Vendor entities (NEW-first structure and utilities).
* Define canonical external identifier shape/validation/generation for Product and Vendor, aligned with the identity foundation pattern already established.
* Add narrowly scoped model-level guarantees and helper behavior needed to store, validate, and safely read canonical Product and Vendor external identifiers without changing external runtime behavior.
* Add focused unit tests proving the foundation invariants for Product and Vendor identity fields/utilities.

## LEGACY path still present

* Existing Mongo-backed runtime behavior and legacy identifiers remain authoritative for this slice.
* Existing read/write behavior that depends on legacy identifiers remains authoritative for this slice.
* No endpoint contracts or API payload semantics are changed in this slice.

## TRANSITIONAL bridge path, if any

* Optional, minimal bridge only at helper/lookup abstraction level if strictly required to connect NEW foundation with current internal model access.
* No read cutover.
* No dual-write introduction.
* No backfill job or migration orchestration.
* If no minimal bridge is required during implementation, this section is treated as intentionally empty.

## Untouched surfaces

* No order, checkout, payment, shipment, invoice, returns, or analytics workflow changes.
* No product catalog behavior changes beyond identity foundation primitives.
* No vendor onboarding/business-process changes.
* No UI/E2E scope expansion.
* No data backfill, no historical rewrite, no operational migration runbook in this slice.

## Hard boundaries

* Keep this slice model/util + focused unit tests only.
* Do not introduce broad repository-wide refactors.
* Do not modify external API contracts.
* Do not start migration execution work; only establish verifiable foundation primitives.
