### PR TITLE
TRAN — Order mirror canonical buyer identity propagation

### DIFF
--- a/backend/prisma/migrations/20260407200000_order_mirror_canonical_identity_fields/migration.sql
+++ b/backend/prisma/migrations/20260407200000_order_mirror_canonical_identity_fields/migration.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "OrderVendorMirror"
+  ADD COLUMN "vendorExternalId" TEXT;
+
+ALTER TABLE "OrderVendorItemMirror"
+  ADD COLUMN "productExternalId" TEXT;
+
+CREATE INDEX "OrderVendorMirror_vendorExternalId_idx" ON "OrderVendorMirror"("vendorExternalId");
+CREATE INDEX "OrderVendorItemMirror_productExternalId_idx" ON "OrderVendorItemMirror"("productExternalId");

--- a/backend/prisma/migrations/20260408193000_order_mirror_buyer_external_id/migration.sql
+++ b/backend/prisma/migrations/20260408193000_order_mirror_buyer_external_id/migration.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "OrderMirror"
+  ADD COLUMN "buyerExternalId" TEXT;
+
+CREATE INDEX "OrderMirror_buyerExternalId_idx" ON "OrderMirror"("buyerExternalId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -11,6 +11,7 @@ model OrderMirror {
   id                 BigInt             @id @default(autoincrement())
   mongoId            String             @unique
   buyerMongoId       String
+  buyerExternalId    String?
   status             String
   currency           String
   paymentMethod      String
@@ -30,6 +31,7 @@ model OrderMirror {
   vendors            OrderVendorMirror[]
 
   @@index([buyerMongoId])
+  @@index([buyerExternalId])
   @@index([mirroredAt])
 }
 

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -38,6 +38,7 @@ model OrderVendorMirror {
   orderMirrorId     BigInt
   orderMirror       OrderMirror            @relation(fields: [orderMirrorId], references: [id], onDelete: Cascade)
   vendorMongoId     String
+  vendorExternalId  String?
   vendorName        String?
   vendorEmail       String?
   invoiceMongoId    String?
@@ -59,6 +60,7 @@ model OrderVendorMirror {
 
   @@index([orderMirrorId])
   @@index([vendorMongoId])
+  @@index([vendorExternalId])
 }
 
 model OrderVendorItemMirror {
@@ -66,6 +68,7 @@ model OrderVendorItemMirror {
   orderVendorId BigInt
   orderVendor   OrderVendorMirror @relation(fields: [orderVendorId], references: [id], onDelete: Cascade)
   productMongoId String
+  productExternalId String?
   name          String?
   quantity      Int
   price         Decimal          @db.Decimal(14, 2)
@@ -74,4 +77,5 @@ model OrderVendorItemMirror {
 
   @@index([orderVendorId])
   @@index([productMongoId])
+  @@index([productExternalId])
 }

--- a/backend/scripts/postgres/checkOrderMirror.js
+++ b/backend/scripts/postgres/checkOrderMirror.js
@@ -9,7 +9,7 @@ const {
   compareMirrorSummary,
   summarizeMirroredOrder,
 } = require("../../services/orderPostgresMirror");
-const { isValidProductExternalId, isValidVendorExternalId } = require("../../utils/externalId");
+const { isValidExternalId, isValidProductExternalId, isValidVendorExternalId } = require("../../utils/externalId");
 
 async function main() {
   const orderId = process.argv[2] || process.env.MONGO_ORDER_ID;
@@ -60,6 +60,8 @@ async function main() {
   const mirroredSummary = summarizeMirroredOrder(mirrored);
   const discrepancies = compareMirrorSummary(sourceSummary, mirroredSummary);
   const richShape = {
+    buyerCanonicalIdPresentWhenBuyerLinked:
+      !mirrored.buyerMongoId || (Boolean(mirrored.buyerExternalId) && isValidExternalId(mirrored.buyerExternalId)),
     vendorNamesPresent: mirrored.vendors.every((vendor) => Boolean(vendor.vendorName)),
     vendorEmailsPresent: mirrored.vendors.every((vendor) => Boolean(vendor.vendorEmail)),
     invoiceLinksPresent: mirrored.vendors.every((vendor) => Boolean(vendor.invoiceMongoId)),

--- a/backend/scripts/postgres/checkOrderMirror.js
+++ b/backend/scripts/postgres/checkOrderMirror.js
@@ -9,6 +9,7 @@ const {
   compareMirrorSummary,
   summarizeMirroredOrder,
 } = require("../../services/orderPostgresMirror");
+const { isValidProductExternalId, isValidVendorExternalId } = require("../../utils/externalId");
 
 async function main() {
   const orderId = process.argv[2] || process.env.MONGO_ORDER_ID;
@@ -62,8 +63,16 @@ async function main() {
     vendorNamesPresent: mirrored.vendors.every((vendor) => Boolean(vendor.vendorName)),
     vendorEmailsPresent: mirrored.vendors.every((vendor) => Boolean(vendor.vendorEmail)),
     invoiceLinksPresent: mirrored.vendors.every((vendor) => Boolean(vendor.invoiceMongoId)),
+    vendorCanonicalIdsPresent: mirrored.vendors.every(
+      (vendor) => Boolean(vendor.vendorExternalId) && isValidVendorExternalId(vendor.vendorExternalId)
+    ),
     itemPricingPresent: mirrored.vendors.every((vendor) =>
       vendor.items.every((item) => item.name && item.price !== null && item.subtotal !== null && item.tax !== null)
+    ),
+    productCanonicalIdsPresent: mirrored.vendors.every((vendor) =>
+      vendor.items.every(
+        (item) => Boolean(item.productExternalId) && isValidProductExternalId(item.productExternalId)
+      )
     ),
   };
 

--- a/backend/scripts/postgres/runtimeProofOrderMirror.js
+++ b/backend/scripts/postgres/runtimeProofOrderMirror.js
@@ -11,7 +11,7 @@ const User = require("../../models/User");
 const Invoice = require("../../models/Invoice");
 const { getPrismaClient, disconnectPrismaClient } = require("../../prisma/client");
 const { summarizeMirroredOrder } = require("../../services/orderPostgresMirror");
-const { isValidProductExternalId, isValidVendorExternalId } = require("../../utils/externalId");
+const { isValidExternalId, isValidProductExternalId, isValidVendorExternalId } = require("../../utils/externalId");
 
 function rid(prefix) {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -119,6 +119,10 @@ async function run() {
   assert.ok(mirrored.vendors.every((vendor) => vendor.vendorName), "Vendor names should be mirrored");
   assert.ok(mirrored.vendors.every((vendor) => vendor.vendorEmail), "Vendor emails should be mirrored");
   assert.ok(mirrored.vendors.every((vendor) => vendor.invoiceMongoId), "Invoice links should be mirrored");
+  assert.ok(
+    !mirrored.buyerMongoId || (mirrored.buyerExternalId && isValidExternalId(mirrored.buyerExternalId)),
+    "Buyer canonical external ID should be mirrored when buyer linkage exists"
+  );
   assert.ok(
     mirrored.vendors.every((vendor) => vendor.vendorExternalId && isValidVendorExternalId(vendor.vendorExternalId)),
     "Vendor canonical external IDs should be mirrored when available"

--- a/backend/scripts/postgres/runtimeProofOrderMirror.js
+++ b/backend/scripts/postgres/runtimeProofOrderMirror.js
@@ -11,6 +11,7 @@ const User = require("../../models/User");
 const Invoice = require("../../models/Invoice");
 const { getPrismaClient, disconnectPrismaClient } = require("../../prisma/client");
 const { summarizeMirroredOrder } = require("../../services/orderPostgresMirror");
+const { isValidProductExternalId, isValidVendorExternalId } = require("../../utils/externalId");
 
 function rid(prefix) {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -119,10 +120,22 @@ async function run() {
   assert.ok(mirrored.vendors.every((vendor) => vendor.vendorEmail), "Vendor emails should be mirrored");
   assert.ok(mirrored.vendors.every((vendor) => vendor.invoiceMongoId), "Invoice links should be mirrored");
   assert.ok(
+    mirrored.vendors.every((vendor) => vendor.vendorExternalId && isValidVendorExternalId(vendor.vendorExternalId)),
+    "Vendor canonical external IDs should be mirrored when available"
+  );
+  assert.ok(
     mirrored.vendors.every((vendor) =>
       vendor.items.every((item) => item.name && item.price !== null && item.subtotal !== null && item.tax !== null)
     ),
     "Item pricing fields should be mirrored"
+  );
+  assert.ok(
+    mirrored.vendors.every((vendor) =>
+      vendor.items.every(
+        (item) => item.productExternalId && isValidProductExternalId(item.productExternalId)
+      )
+    ),
+    "Product canonical external IDs should be mirrored when available"
   );
 
   const responseInvariant = {

--- a/backend/services/orderPostgresMirror.js
+++ b/backend/services/orderPostgresMirror.js
@@ -1,7 +1,7 @@
 const { getPrismaClient } = require("../prisma/client");
 const User = require("../models/User");
 const Product = require("../models/Product");
-const { isValidProductExternalId, isValidVendorExternalId } = require("../utils/externalId");
+const { isValidExternalId, isValidProductExternalId, isValidVendorExternalId } = require("../utils/externalId");
 
 const VALID_MIRROR_MODES = new Set(["off", "best_effort"]);
 
@@ -65,6 +65,27 @@ function buildExternalIdLookup(documents, validator) {
     lookup.set(String(doc._id), normalizedExternalId);
   });
   return lookup;
+}
+
+async function resolveBuyerExternalId(order) {
+  const explicitBuyerExternalId = normalizeExternalId(
+    order && (order.buyerExternalId || order.buyerCanonicalExternalId),
+    isValidExternalId
+  );
+  if (explicitBuyerExternalId) return explicitBuyerExternalId;
+
+  const buyerMongoId = order && order.buyer ? String(order.buyer) : "";
+  if (!buyerMongoId) return null;
+
+  try {
+    const buyerDoc = await User.findById(buyerMongoId).select("_id externalId").lean();
+    if (!buyerDoc) return null;
+    return normalizeExternalId(buyerDoc.externalId, isValidExternalId);
+  } catch (error) {
+    const message = error && error.message ? error.message : String(error);
+    console.warn(`[orders-postgres-mirror] Canonical buyer identity enrichment fallback: ${message}`);
+    return null;
+  }
 }
 
 async function enrichVendorsWithCanonicalIdentity(vendors) {
@@ -229,6 +250,7 @@ function compareMirrorSummary(sourceSummary, mirroredSummary) {
 }
 
 async function buildMirrorPayload(order, vendors) {
+  const buyerExternalId = await resolveBuyerExternalId(order);
   const enrichedVendors = await enrichVendorsWithCanonicalIdentity(vendors);
   const sourceSummary = buildMirrorSummary(order, enrichedVendors);
 
@@ -236,6 +258,7 @@ async function buildMirrorPayload(order, vendors) {
     sourceSummary,
     data: {
       buyerMongoId: order.buyer ? String(order.buyer) : "",
+      buyerExternalId,
       status: order.status || "pending",
       currency: order.currency || "USD",
       paymentMethod: order.paymentMethod || "cod",
@@ -335,6 +358,7 @@ module.exports = {
   compareMirrorSummary,
   enrichVendorsWithCanonicalIdentity,
   mirrorOrderCreationToPostgres,
+  resolveBuyerExternalId,
   resolveOrdersPgMirrorMode,
   summarizeMirroredOrder,
 };

--- a/backend/services/orderPostgresMirror.js
+++ b/backend/services/orderPostgresMirror.js
@@ -1,4 +1,7 @@
 const { getPrismaClient } = require("../prisma/client");
+const User = require("../models/User");
+const Product = require("../models/Product");
+const { isValidProductExternalId, isValidVendorExternalId } = require("../utils/externalId");
 
 const VALID_MIRROR_MODES = new Set(["off", "best_effort"]);
 
@@ -45,6 +48,96 @@ function asJsonOrNull(value) {
   return value;
 }
 
+function normalizeExternalId(value, validator) {
+  if (!value) return null;
+  const normalized = String(value).trim().toLowerCase();
+  if (!normalized) return null;
+  return validator(normalized) ? normalized : null;
+}
+
+function buildExternalIdLookup(documents, validator) {
+  const lookup = new Map();
+  const docs = Array.isArray(documents) ? documents : [];
+  docs.forEach((doc) => {
+    if (!doc || !doc._id) return;
+    const normalizedExternalId = normalizeExternalId(doc.externalId, validator);
+    if (!normalizedExternalId) return;
+    lookup.set(String(doc._id), normalizedExternalId);
+  });
+  return lookup;
+}
+
+async function enrichVendorsWithCanonicalIdentity(vendors) {
+  const normalizedVendors = Array.isArray(vendors) ? vendors : [];
+  if (normalizedVendors.length === 0) return [];
+
+  const vendorMongoIds = Array.from(
+    new Set(
+      normalizedVendors
+        .map((vendor) => (vendor && vendor.vendorId ? String(vendor.vendorId) : ""))
+        .filter(Boolean)
+    )
+  );
+  const productMongoIds = Array.from(
+    new Set(
+      normalizedVendors
+        .flatMap((vendor) => (Array.isArray(vendor && vendor.products) ? vendor.products : []))
+        .map((product) => (product && product.product ? String(product.product) : ""))
+        .filter(Boolean)
+    )
+  );
+
+  let vendorExternalIdLookup = new Map();
+  let productExternalIdLookup = new Map();
+
+  if (vendorMongoIds.length > 0 || productMongoIds.length > 0) {
+    try {
+      const [vendorDocs, productDocs] = await Promise.all([
+        vendorMongoIds.length > 0
+          ? User.find({ _id: { $in: vendorMongoIds } }).select("_id externalId").lean()
+          : [],
+        productMongoIds.length > 0
+          ? Product.find({ _id: { $in: productMongoIds } }).select("_id externalId").lean()
+          : [],
+      ]);
+
+      vendorExternalIdLookup = buildExternalIdLookup(vendorDocs, isValidVendorExternalId);
+      productExternalIdLookup = buildExternalIdLookup(productDocs, isValidProductExternalId);
+    } catch (error) {
+      const message = error && error.message ? error.message : String(error);
+      console.warn(`[orders-postgres-mirror] Canonical identity enrichment fallback: ${message}`);
+    }
+  }
+
+  return normalizedVendors.map((vendor) => {
+    const vendorMongoId = vendor && vendor.vendorId ? String(vendor.vendorId) : "";
+    const explicitVendorExternalId = normalizeExternalId(
+      vendor && (vendor.vendorExternalId || vendor.vendorCanonicalExternalId),
+      isValidVendorExternalId
+    );
+
+    const products = Array.isArray(vendor && vendor.products) ? vendor.products : [];
+    const enrichedProducts = products.map((product) => {
+      const productMongoId = product && product.product ? String(product.product) : "";
+      const explicitProductExternalId = normalizeExternalId(
+        product && (product.productExternalId || product.productCanonicalExternalId),
+        isValidProductExternalId
+      );
+
+      return {
+        ...(product || {}),
+        productExternalId: explicitProductExternalId || productExternalIdLookup.get(productMongoId) || null,
+      };
+    });
+
+    return {
+      ...(vendor || {}),
+      vendorExternalId: explicitVendorExternalId || vendorExternalIdLookup.get(vendorMongoId) || null,
+      products: enrichedProducts,
+    };
+  });
+}
+
 function buildVendorRows(vendors) {
   if (!Array.isArray(vendors)) return [];
 
@@ -53,6 +146,7 @@ function buildVendorRows(vendors) {
 
     return {
       vendorMongoId: vendor.vendorId ? String(vendor.vendorId) : "",
+      vendorExternalId: normalizeExternalId(vendor.vendorExternalId, isValidVendorExternalId),
       vendorName: vendor.vendorName || null,
       vendorEmail: vendor.vendorEmail || null,
       invoiceMongoId: vendor.invoiceId ? String(vendor.invoiceId) : null,
@@ -73,6 +167,7 @@ function buildVendorRows(vendors) {
       items: {
         create: products.map((product) => ({
           productMongoId: product.product ? String(product.product) : "",
+          productExternalId: normalizeExternalId(product.productExternalId, isValidProductExternalId),
           name: product.name || null,
           quantity: Number(product.quantity || 0),
           price: toMoney(product.price),
@@ -133,8 +228,9 @@ function compareMirrorSummary(sourceSummary, mirroredSummary) {
   return discrepancies;
 }
 
-function buildMirrorPayload(order, vendors) {
-  const sourceSummary = buildMirrorSummary(order, vendors);
+async function buildMirrorPayload(order, vendors) {
+  const enrichedVendors = await enrichVendorsWithCanonicalIdentity(vendors);
+  const sourceSummary = buildMirrorSummary(order, enrichedVendors);
 
   return {
     sourceSummary,
@@ -156,7 +252,7 @@ function buildMirrorPayload(order, vendors) {
       sourceCreatedAt: toDate(order.createdAt),
       sourceUpdatedAt: toDate(order.updatedAt),
       vendors: {
-        create: buildVendorRows(vendors),
+        create: buildVendorRows(enrichedVendors),
       },
     },
   };
@@ -174,7 +270,7 @@ async function mirrorOrderCreationToPostgres({ order, vendors }) {
 
   const orderMongoId = String(order._id);
   const prisma = getPrismaClient();
-  const { data, sourceSummary } = buildMirrorPayload(order, vendors);
+  const { data, sourceSummary } = await buildMirrorPayload(order, vendors);
 
   try {
     const existing = await prisma.orderMirror.findUnique({
@@ -198,7 +294,7 @@ async function mirrorOrderCreationToPostgres({ order, vendors }) {
         ...data,
         vendors: {
           deleteMany: {},
-          create: buildVendorRows(vendors),
+          create: data.vendors.create,
         },
       },
       include: {
@@ -237,6 +333,7 @@ module.exports = {
   buildMirrorSummary,
   buildVendorRows,
   compareMirrorSummary,
+  enrichVendorsWithCanonicalIdentity,
   mirrorOrderCreationToPostgres,
   resolveOrdersPgMirrorMode,
   summarizeMirroredOrder,

--- a/backend/tests/unit/services/orderPostgresMirror.test.js
+++ b/backend/tests/unit/services/orderPostgresMirror.test.js
@@ -2,15 +2,19 @@ const {
   buildMirrorSummary,
   buildVendorRows,
   compareMirrorSummary,
+  enrichVendorsWithCanonicalIdentity,
   resolveOrdersPgMirrorMode,
   summarizeMirroredOrder,
 } = require("../../../services/orderPostgresMirror");
+const Product = require("../../../models/Product");
+const User = require("../../../models/User");
 
 describe("orderPostgresMirror", () => {
   const originalEnv = { ...process.env };
 
   afterEach(() => {
     process.env = { ...originalEnv };
+    jest.restoreAllMocks();
   });
 
   test("falls back to off when mirror mode is invalid", () => {
@@ -51,12 +55,14 @@ describe("orderPostgresMirror", () => {
 
     expect(rows[0]).toMatchObject({
       vendorMongoId: "vendor-1",
+      vendorExternalId: null,
       vendorName: "Vendor One",
       vendorEmail: "vendor@example.com",
       invoiceMongoId: "invoice-1",
     });
     expect(rows[0].items.create[0]).toMatchObject({
       productMongoId: "product-1",
+      productExternalId: null,
       name: "Mirror Product",
       quantity: 2,
       price: "12.50",
@@ -136,5 +142,57 @@ describe("orderPostgresMirror", () => {
       itemCount: 3,
       invoiceCount: 2,
     });
+  });
+
+  test("enriches vendor/product canonical IDs from Mongo lookups", async () => {
+    const userFindSpy = jest.spyOn(User, "find").mockReturnValue({
+      select: () => ({
+        lean: () => Promise.resolve([{ _id: "vendor-1", externalId: "uid_11111111111111111111" }]),
+      }),
+    });
+    const productFindSpy = jest.spyOn(Product, "find").mockReturnValue({
+      select: () => ({
+        lean: () => Promise.resolve([{ _id: "product-1", externalId: "pid_11111111111111111111" }]),
+      }),
+    });
+
+    const enriched = await enrichVendorsWithCanonicalIdentity([
+      {
+        vendorId: "vendor-1",
+        products: [{ product: "product-1", name: "Mirror Product", quantity: 1, price: 10 }],
+      },
+    ]);
+
+    expect(userFindSpy).toHaveBeenCalledWith({ _id: { $in: ["vendor-1"] } });
+    expect(productFindSpy).toHaveBeenCalledWith({ _id: { $in: ["product-1"] } });
+    expect(enriched[0].vendorExternalId).toBe("uid_11111111111111111111");
+    expect(enriched[0].products[0].productExternalId).toBe("pid_11111111111111111111");
+  });
+
+  test("buildVendorRows keeps canonical IDs additive and nullable", () => {
+    const rows = buildVendorRows([
+      {
+        vendorId: "vendor-1",
+        vendorExternalId: "uid_aaaaaaaaaaaaaaaaaaaa",
+        products: [
+          {
+            product: "product-1",
+            productExternalId: "pid_bbbbbbbbbbbbbbbbbbbb",
+            quantity: 1,
+            price: 10,
+          },
+          {
+            product: "product-2",
+            productExternalId: "invalid",
+            quantity: 1,
+            price: 12,
+          },
+        ],
+      },
+    ]);
+
+    expect(rows[0].vendorExternalId).toBe("uid_aaaaaaaaaaaaaaaaaaaa");
+    expect(rows[0].items.create[0].productExternalId).toBe("pid_bbbbbbbbbbbbbbbbbbbb");
+    expect(rows[0].items.create[1].productExternalId).toBeNull();
   });
 });

--- a/backend/tests/unit/services/orderPostgresMirror.test.js
+++ b/backend/tests/unit/services/orderPostgresMirror.test.js
@@ -1,8 +1,10 @@
 const {
+  buildMirrorPayload,
   buildMirrorSummary,
   buildVendorRows,
   compareMirrorSummary,
   enrichVendorsWithCanonicalIdentity,
+  resolveBuyerExternalId,
   resolveOrdersPgMirrorMode,
   summarizeMirroredOrder,
 } = require("../../../services/orderPostgresMirror");
@@ -194,5 +196,64 @@ describe("orderPostgresMirror", () => {
     expect(rows[0].vendorExternalId).toBe("uid_aaaaaaaaaaaaaaaaaaaa");
     expect(rows[0].items.create[0].productExternalId).toBe("pid_bbbbbbbbbbbbbbbbbbbb");
     expect(rows[0].items.create[1].productExternalId).toBeNull();
+  });
+
+  test("resolveBuyerExternalId prefers explicit canonical buyer ID", async () => {
+    const findByIdSpy = jest.spyOn(User, "findById");
+
+    const result = await resolveBuyerExternalId({
+      buyer: "buyer-1",
+      buyerExternalId: "UID_AAAAAAAAAAAAAAAAAAAA",
+    });
+
+    expect(result).toBe("uid_aaaaaaaaaaaaaaaaaaaa");
+    expect(findByIdSpy).not.toHaveBeenCalled();
+  });
+
+  test("resolveBuyerExternalId falls back to buyer lookup when explicit value missing", async () => {
+    const findByIdSpy = jest.spyOn(User, "findById").mockReturnValue({
+      select: () => ({
+        lean: () => Promise.resolve({ _id: "buyer-1", externalId: "uid_cccccccccccccccccccc" }),
+      }),
+    });
+
+    const result = await resolveBuyerExternalId({ buyer: "buyer-1" });
+
+    expect(findByIdSpy).toHaveBeenCalledWith("buyer-1");
+    expect(result).toBe("uid_cccccccccccccccccccc");
+  });
+
+  test("buildMirrorPayload keeps buyer canonical ID additive with absence fallback", async () => {
+    jest.spyOn(User, "findById").mockReturnValue({
+      select: () => ({ lean: () => Promise.resolve(null) }),
+    });
+
+    const withExplicitBuyerId = await buildMirrorPayload(
+      {
+        _id: "order-1",
+        buyer: "buyer-1",
+        buyerExternalId: "uid_dddddddddddddddddddd",
+        total: 20,
+        totalAfterDiscount: 18,
+        discount: 2,
+      },
+      []
+    );
+
+    const withMissingBuyerId = await buildMirrorPayload(
+      {
+        _id: "order-2",
+        buyer: "buyer-2",
+        total: 20,
+        totalAfterDiscount: 20,
+        discount: 0,
+      },
+      []
+    );
+
+    expect(withExplicitBuyerId.data.buyerMongoId).toBe("buyer-1");
+    expect(withExplicitBuyerId.data.buyerExternalId).toBe("uid_dddddddddddddddddddd");
+    expect(withMissingBuyerId.data.buyerMongoId).toBe("buyer-2");
+    expect(withMissingBuyerId.data.buyerExternalId).toBeNull();
   });
 });

--- a/docs/issues/tran-order-mirror-canonical-buyer-identity-propagation.md
+++ b/docs/issues/tran-order-mirror-canonical-buyer-identity-propagation.md
@@ -1,0 +1,44 @@
+Title: Scope Lock — TRAN: Order mirror canonical buyer identity propagation
+
+Intent
+Propagate canonical buyer identity into the existing order mirror transitional path only.
+This slice is bridge-only and must not introduce read cutover, write cutover, or broad workflow changes.
+
+NEW canonical path
+
+* Treat canonical buyer external identity from the established identity foundation as source input only.
+* Do not redefine canonical identity formats, generation rules, or model contracts in this slice.
+* Consume existing canonical identity primitives strictly for transitional mirror shaping/persistence.
+
+LEGACY path still present
+
+* Existing Mongo-backed order runtime remains authoritative.
+* Existing legacy Mongo ObjectId-based behavior remains authoritative for all live reads/writes.
+* No endpoint contract changes and no API payload semantic changes.
+
+TRANSITIONAL bridge path, if any
+
+* Update only transitional order mirror shaping/persistence to include canonical buyer identity when available.
+* Preserve current mirror behavior when canonical buyer identity is absent.
+* Keep legacy mirror fields intact for backward compatibility.
+* Keep mirror writes additive and non-breaking.
+* No read cutover.
+* No dual-write expansion beyond the existing mirror path.
+* No backfill jobs.
+* No migration orchestration.
+
+Untouched surfaces
+
+* No checkout, payment, shipment, invoice, returns, or analytics behavior changes.
+* No product catalog business logic changes.
+* No vendor onboarding/account-management changes.
+* No UI/E2E scope expansion beyond proof updates strictly required by this bridge field propagation.
+* No schema-wide refactors outside strictly required mirror payload fields/tests.
+
+Hard boundaries
+
+* Restrict changes to transitional mirror service/script/test surfaces required for canonical buyer identity propagation.
+* Add focused proof for additive mirror payload behavior only (presence/absence handling and non-breaking invariants).
+* Preserve existing runtime behavior and public API contracts.
+* Do not introduce destination cutover logic.
+* MongoDB touches are allowed only where directly required to enable PostgreSQL transition proof for this field propagation; no broad Mongo stabilization.

--- a/docs/issues/tran-order-mirror-canonical-identity-propagation.md
+++ b/docs/issues/tran-order-mirror-canonical-identity-propagation.md
@@ -1,0 +1,46 @@
+# Scope Lock - TRAN: Order Mirror Canonical Product/Vendor Identity Propagation
+
+## Intent
+
+Propagate canonical product and vendor identity keys into the existing order mirror transitional path only.
+This slice is bridge-only and must not introduce read cutover, write cutover, or broad workflow changes.
+
+## NEW canonical path
+
+* Treat canonical identity foundations as source fields only:
+
+  * user external identity for vendors
+  * product external identity for products
+* Do not redefine NEW identity formats or model contracts in this slice.
+* Consume existing NEW identity primitives as inputs to transitional mirror shaping.
+
+## LEGACY path still present
+
+* Existing Mongo-backed order runtime remains authoritative.
+* Existing legacy Mongo ObjectId-based behavior remains authoritative for all live reads/writes.
+* No endpoint contract changes and no API payload semantic changes.
+
+## TRANSITIONAL bridge path, if any
+
+* Update only transitional order mirror shaping and persistence payloads to include canonical vendor/product identity fields when available, while preserving current mirror behavior when they are absent.
+* Keep legacy mirror fields intact for backward compatibility.
+* Keep mirror writes additive and non-breaking.
+* No read cutover.
+* No dual-write expansion beyond existing mirror path.
+* No backfill jobs.
+* No migration orchestration.
+
+## Untouched surfaces
+
+* No checkout, payment, shipment, invoice, returns, or analytics behavior changes.
+* No product catalog business logic changes.
+* No vendor onboarding or account-management changes.
+* No UI/E2E scope expansion.
+* No schema-wide refactors outside strictly required mirror payload fields.
+
+## Hard boundaries
+
+* Restrict changes to transitional mirror service/script/test surfaces required for canonical identity propagation.
+* Add focused unit/integration proof for additive mirror payload behavior only.
+* Preserve existing runtime behavior and existing public API contracts.
+* Do not introduce destination cutover logic.


### PR DESCRIPTION
## NEW canonical path

* Treat canonical buyer external identity from the established identity foundation as source input only.
* Do not redefine canonical identity formats, generation rules, or model contracts in this slice.
* Consume existing canonical identity primitives strictly for transitional mirror shaping/persistence.

## LEGACY path still present

* Existing Mongo-backed order runtime remains authoritative.
* Existing legacy Mongo ObjectId-based behavior remains authoritative for all live reads/writes.
* No endpoint contract changes and no API payload semantic changes.

## TRANSITIONAL bridge path, if any

* Update only transitional order mirror shaping/persistence to include canonical buyer identity when available.
* Preserve current mirror behavior when canonical buyer identity is absent.
* Keep legacy mirror fields intact for backward compatibility.
* Keep mirror writes additive and non-breaking.
* No read cutover.
* No dual-write expansion beyond the existing mirror path.
* No backfill jobs.
* No migration orchestration.

## HARD BOUNDARIES

* Restrict changes to transitional mirror service/script/test surfaces required for canonical buyer identity propagation.
* Add focused proof for additive mirror payload behavior only (presence/absence handling and non-breaking invariants).
* Preserve existing runtime behavior and public API contracts.
* Do not introduce destination cutover logic.
* MongoDB touches are allowed only where directly required to enable PostgreSQL transition proof for this field propagation; no broad Mongo stabilization.

## Proof Checklist

- [ ] additive mirror write
- [ ] absence fallback
- [ ] no API contract drift
- [ ] CI mirror proof green

## Scope-Lock Source

- Issue #74
- Scope-lock file: docs/issues/tran-order-mirror-canonical-buyer-identity-propagation.md