### PR TITLE
TRAN - Order mirror canonical buyer identity propagation (clean replacement)

### DIFF
--- a/backend/prisma/migrations/20260408193000_order_mirror_buyer_external_id/migration.sql
+++ b/backend/prisma/migrations/20260408193000_order_mirror_buyer_external_id/migration.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "OrderMirror"
+  ADD COLUMN "buyerExternalId" TEXT;
+
+CREATE INDEX "OrderMirror_buyerExternalId_idx" ON "OrderMirror"("buyerExternalId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -11,6 +11,7 @@ model OrderMirror {
   id                 BigInt             @id @default(autoincrement())
   mongoId            String             @unique
   buyerMongoId       String
+  buyerExternalId    String?
   status             String
   currency           String
   paymentMethod      String
@@ -30,6 +31,7 @@ model OrderMirror {
   vendors            OrderVendorMirror[]
 
   @@index([buyerMongoId])
+  @@index([buyerExternalId])
   @@index([mirroredAt])
 }
 

--- a/backend/scripts/postgres/checkOrderMirror.js
+++ b/backend/scripts/postgres/checkOrderMirror.js
@@ -9,7 +9,7 @@ const {
   compareMirrorSummary,
   summarizeMirroredOrder,
 } = require("../../services/orderPostgresMirror");
-const { isValidProductExternalId, isValidVendorExternalId } = require("../../utils/externalId");
+const { isValidExternalId, isValidProductExternalId, isValidVendorExternalId } = require("../../utils/externalId");
 
 async function main() {
   const orderId = process.argv[2] || process.env.MONGO_ORDER_ID;
@@ -60,6 +60,8 @@ async function main() {
   const mirroredSummary = summarizeMirroredOrder(mirrored);
   const discrepancies = compareMirrorSummary(sourceSummary, mirroredSummary);
   const richShape = {
+    buyerCanonicalIdPresentWhenBuyerLinked:
+      !mirrored.buyerMongoId || (Boolean(mirrored.buyerExternalId) && isValidExternalId(mirrored.buyerExternalId)),
     vendorNamesPresent: mirrored.vendors.every((vendor) => Boolean(vendor.vendorName)),
     vendorEmailsPresent: mirrored.vendors.every((vendor) => Boolean(vendor.vendorEmail)),
     invoiceLinksPresent: mirrored.vendors.every((vendor) => Boolean(vendor.invoiceMongoId)),

--- a/backend/scripts/postgres/runtimeProofOrderMirror.js
+++ b/backend/scripts/postgres/runtimeProofOrderMirror.js
@@ -11,7 +11,7 @@ const User = require("../../models/User");
 const Invoice = require("../../models/Invoice");
 const { getPrismaClient, disconnectPrismaClient } = require("../../prisma/client");
 const { summarizeMirroredOrder } = require("../../services/orderPostgresMirror");
-const { isValidProductExternalId, isValidVendorExternalId } = require("../../utils/externalId");
+const { isValidExternalId, isValidProductExternalId, isValidVendorExternalId } = require("../../utils/externalId");
 
 function rid(prefix) {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -119,6 +119,10 @@ async function run() {
   assert.ok(mirrored.vendors.every((vendor) => vendor.vendorName), "Vendor names should be mirrored");
   assert.ok(mirrored.vendors.every((vendor) => vendor.vendorEmail), "Vendor emails should be mirrored");
   assert.ok(mirrored.vendors.every((vendor) => vendor.invoiceMongoId), "Invoice links should be mirrored");
+  assert.ok(
+    !mirrored.buyerMongoId || (mirrored.buyerExternalId && isValidExternalId(mirrored.buyerExternalId)),
+    "Buyer canonical external ID should be mirrored when buyer linkage exists"
+  );
   assert.ok(
     mirrored.vendors.every((vendor) => vendor.vendorExternalId && isValidVendorExternalId(vendor.vendorExternalId)),
     "Vendor canonical external IDs should be mirrored when available"

--- a/backend/services/orderPostgresMirror.js
+++ b/backend/services/orderPostgresMirror.js
@@ -1,7 +1,7 @@
 const { getPrismaClient } = require("../prisma/client");
 const User = require("../models/User");
 const Product = require("../models/Product");
-const { isValidProductExternalId, isValidVendorExternalId } = require("../utils/externalId");
+const { isValidExternalId, isValidProductExternalId, isValidVendorExternalId } = require("../utils/externalId");
 
 const VALID_MIRROR_MODES = new Set(["off", "best_effort"]);
 
@@ -65,6 +65,27 @@ function buildExternalIdLookup(documents, validator) {
     lookup.set(String(doc._id), normalizedExternalId);
   });
   return lookup;
+}
+
+async function resolveBuyerExternalId(order) {
+  const explicitBuyerExternalId = normalizeExternalId(
+    order && (order.buyerExternalId || order.buyerCanonicalExternalId),
+    isValidExternalId
+  );
+  if (explicitBuyerExternalId) return explicitBuyerExternalId;
+
+  const buyerMongoId = order && order.buyer ? String(order.buyer) : "";
+  if (!buyerMongoId) return null;
+
+  try {
+    const buyerDoc = await User.findById(buyerMongoId).select("_id externalId").lean();
+    if (!buyerDoc) return null;
+    return normalizeExternalId(buyerDoc.externalId, isValidExternalId);
+  } catch (error) {
+    const message = error && error.message ? error.message : String(error);
+    console.warn(`[orders-postgres-mirror] Canonical buyer identity enrichment fallback: ${message}`);
+    return null;
+  }
 }
 
 async function enrichVendorsWithCanonicalIdentity(vendors) {
@@ -229,6 +250,7 @@ function compareMirrorSummary(sourceSummary, mirroredSummary) {
 }
 
 async function buildMirrorPayload(order, vendors) {
+  const buyerExternalId = await resolveBuyerExternalId(order);
   const enrichedVendors = await enrichVendorsWithCanonicalIdentity(vendors);
   const sourceSummary = buildMirrorSummary(order, enrichedVendors);
 
@@ -236,6 +258,7 @@ async function buildMirrorPayload(order, vendors) {
     sourceSummary,
     data: {
       buyerMongoId: order.buyer ? String(order.buyer) : "",
+      buyerExternalId,
       status: order.status || "pending",
       currency: order.currency || "USD",
       paymentMethod: order.paymentMethod || "cod",
@@ -335,6 +358,7 @@ module.exports = {
   compareMirrorSummary,
   enrichVendorsWithCanonicalIdentity,
   mirrorOrderCreationToPostgres,
+  resolveBuyerExternalId,
   resolveOrdersPgMirrorMode,
   summarizeMirroredOrder,
 };

--- a/backend/tests/unit/services/orderPostgresMirror.test.js
+++ b/backend/tests/unit/services/orderPostgresMirror.test.js
@@ -1,8 +1,10 @@
 const {
+  buildMirrorPayload,
   buildMirrorSummary,
   buildVendorRows,
   compareMirrorSummary,
   enrichVendorsWithCanonicalIdentity,
+  resolveBuyerExternalId,
   resolveOrdersPgMirrorMode,
   summarizeMirroredOrder,
 } = require("../../../services/orderPostgresMirror");
@@ -194,5 +196,64 @@ describe("orderPostgresMirror", () => {
     expect(rows[0].vendorExternalId).toBe("uid_aaaaaaaaaaaaaaaaaaaa");
     expect(rows[0].items.create[0].productExternalId).toBe("pid_bbbbbbbbbbbbbbbbbbbb");
     expect(rows[0].items.create[1].productExternalId).toBeNull();
+  });
+
+  test("resolveBuyerExternalId prefers explicit canonical buyer ID", async () => {
+    const findByIdSpy = jest.spyOn(User, "findById");
+
+    const result = await resolveBuyerExternalId({
+      buyer: "buyer-1",
+      buyerExternalId: "UID_AAAAAAAAAAAAAAAAAAAA",
+    });
+
+    expect(result).toBe("uid_aaaaaaaaaaaaaaaaaaaa");
+    expect(findByIdSpy).not.toHaveBeenCalled();
+  });
+
+  test("resolveBuyerExternalId falls back to buyer lookup when explicit value missing", async () => {
+    const findByIdSpy = jest.spyOn(User, "findById").mockReturnValue({
+      select: () => ({
+        lean: () => Promise.resolve({ _id: "buyer-1", externalId: "uid_cccccccccccccccccccc" }),
+      }),
+    });
+
+    const result = await resolveBuyerExternalId({ buyer: "buyer-1" });
+
+    expect(findByIdSpy).toHaveBeenCalledWith("buyer-1");
+    expect(result).toBe("uid_cccccccccccccccccccc");
+  });
+
+  test("buildMirrorPayload keeps buyer canonical ID additive with absence fallback", async () => {
+    jest.spyOn(User, "findById").mockReturnValue({
+      select: () => ({ lean: () => Promise.resolve(null) }),
+    });
+
+    const withExplicitBuyerId = await buildMirrorPayload(
+      {
+        _id: "order-1",
+        buyer: "buyer-1",
+        buyerExternalId: "uid_dddddddddddddddddddd",
+        total: 20,
+        totalAfterDiscount: 18,
+        discount: 2,
+      },
+      []
+    );
+
+    const withMissingBuyerId = await buildMirrorPayload(
+      {
+        _id: "order-2",
+        buyer: "buyer-2",
+        total: 20,
+        totalAfterDiscount: 20,
+        discount: 0,
+      },
+      []
+    );
+
+    expect(withExplicitBuyerId.data.buyerMongoId).toBe("buyer-1");
+    expect(withExplicitBuyerId.data.buyerExternalId).toBe("uid_dddddddddddddddddddd");
+    expect(withMissingBuyerId.data.buyerMongoId).toBe("buyer-2");
+    expect(withMissingBuyerId.data.buyerExternalId).toBeNull();
   });
 });

--- a/docs/issues/tran-order-mirror-canonical-buyer-identity-propagation.md
+++ b/docs/issues/tran-order-mirror-canonical-buyer-identity-propagation.md
@@ -1,0 +1,44 @@
+Title: Scope Lock — TRAN: Order mirror canonical buyer identity propagation
+
+Intent
+Propagate canonical buyer identity into the existing order mirror transitional path only.
+This slice is bridge-only and must not introduce read cutover, write cutover, or broad workflow changes.
+
+NEW canonical path
+
+* Treat canonical buyer external identity from the established identity foundation as source input only.
+* Do not redefine canonical identity formats, generation rules, or model contracts in this slice.
+* Consume existing canonical identity primitives strictly for transitional mirror shaping/persistence.
+
+LEGACY path still present
+
+* Existing Mongo-backed order runtime remains authoritative.
+* Existing legacy Mongo ObjectId-based behavior remains authoritative for all live reads/writes.
+* No endpoint contract changes and no API payload semantic changes.
+
+TRANSITIONAL bridge path, if any
+
+* Update only transitional order mirror shaping/persistence to include canonical buyer identity when available.
+* Preserve current mirror behavior when canonical buyer identity is absent.
+* Keep legacy mirror fields intact for backward compatibility.
+* Keep mirror writes additive and non-breaking.
+* No read cutover.
+* No dual-write expansion beyond the existing mirror path.
+* No backfill jobs.
+* No migration orchestration.
+
+Untouched surfaces
+
+* No checkout, payment, shipment, invoice, returns, or analytics behavior changes.
+* No product catalog business logic changes.
+* No vendor onboarding/account-management changes.
+* No UI/E2E scope expansion beyond proof updates strictly required by this bridge field propagation.
+* No schema-wide refactors outside strictly required mirror payload fields/tests.
+
+Hard boundaries
+
+* Restrict changes to transitional mirror service/script/test surfaces required for canonical buyer identity propagation.
+* Add focused proof for additive mirror payload behavior only (presence/absence handling and non-breaking invariants).
+* Preserve existing runtime behavior and public API contracts.
+* Do not introduce destination cutover logic.
+* MongoDB touches are allowed only where directly required to enable PostgreSQL transition proof for this field propagation; no broad Mongo stabilization.


### PR DESCRIPTION
## Scope\nClean replacement vehicle for the TRAN buyer identity propagation slice.\n\n## Supersession\nSupersedes #75 as the active vehicle to enforce a clean governed branch and PR surface.\n\n## Included\n- buyerExternalId additive mirror schema field and index\n- buyer canonical identity propagation in order mirror payload\n- buyer-focused runtime proof and check assertions\n- buyer-focused unit tests\n- buyer slice scope-lock doc\n\n## Excluded\n- vendor/product carryover hunks\n- prior vendor/product migration and scope-lock doc\n\n## Governance\n- TRAN classification preserved\n- Mongo touches transition-enabling and additive only\n- no read or write cutover introduced