### PR TITLE
Scope Lock — NEW: Order and invoice external-ID foundation

### DIFF
--- a/backend/models/Invoice.js
+++ b/backend/models/Invoice.js
@@ -1,29 +1,125 @@
 const mongoose = require('mongoose');
+const {
+  generateInvoiceExternalId,
+  isLikelyMongoObjectId,
+  isValidInvoiceExternalId,
+} = require('../utils/externalId');
 
-const invoiceSchema = new mongoose.Schema({
-  vendor: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
-  customer: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
-  order: { type: mongoose.Schema.Types.ObjectId, ref: 'Order' },
-  items: [
-    {
-      product: { type: mongoose.Schema.Types.ObjectId, ref: 'Product' },
-      name: String,
-      quantity: Number,
-      price: Number,
-      subtotal: Number,
-      tax: Number
+const invoiceSchema = new mongoose.Schema(
+  {
+    externalId: {
+      type: String,
+      unique: true,
+      sparse: true,
+      immutable: true,
+      lowercase: true,
+      trim: true,
+      select: false,
+      validate: {
+        validator: (value) => !value || isValidInvoiceExternalId(value),
+        message: 'Invalid canonical invoice external ID format',
+      },
+    },
+    vendor: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },
+    customer: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
+    order: { type: mongoose.Schema.Types.ObjectId, ref: 'Order' },
+    items: [
+      {
+        product: { type: mongoose.Schema.Types.ObjectId, ref: 'Product' },
+        name: String,
+        quantity: Number,
+        price: Number,
+        subtotal: Number,
+        tax: Number
+      }
+    ],
+    subtotal: Number,
+    tax: Number,
+    shipping: Number,
+    discount: Number,
+    commission: Number,
+    total: Number,
+    netAmount: Number,
+    currency: { type: String, default: 'USD' },
+    dueDate: { type: Date },
+    paidAt: { type: Date }
+  },
+  {
+    timestamps: true,
+    toJSON: {
+      transform: (_doc, ret) => {
+        delete ret.externalId;
+        return ret;
+      },
+    },
+    toObject: {
+      transform: (_doc, ret) => {
+        delete ret.externalId;
+        return ret;
+      },
+    },
+  }
+);
+
+invoiceSchema.pre('validate', async function (next) {
+  try {
+    if (this.isNew && !this.externalId) {
+      this.externalId = generateInvoiceExternalId();
+      if (String(process.env.INVOICE_EXTERNAL_ID_LOG || '').toLowerCase() === 'true') {
+        console.info(`[invoice-foundation] Assigned externalId=${this.externalId} for invoiceMongoId=${String(this._id)}`);
+      }
     }
-  ],
-  subtotal: Number,
-  tax: Number,
-  shipping: Number,
-  discount: Number,
-  commission: Number,
-  total: Number,
-  netAmount: Number,
-  currency: { type: String, default: 'USD' },
-  dueDate: { type: Date },
-  paidAt: { type: Date }
-}, { timestamps: true });
+
+    if (!this.isNew && this.isModified('externalId')) {
+      this.invalidate('externalId', 'externalId is immutable once assigned');
+      return next();
+    }
+
+    const needsUniquenessCheck = this.externalId && (this.isNew || this.isModified('externalId'));
+    if (!needsUniquenessCheck) {
+      return next();
+    }
+
+    const allowCheckWhileDisconnected =
+      String(process.env.INVOICE_EXTERNAL_ID_TEST_UNIQUENESS || '').toLowerCase() === 'true';
+    const hasLiveDbConnection = this.constructor.db && this.constructor.db.readyState === 1;
+    if (!hasLiveDbConnection && !allowCheckWhileDisconnected) {
+      return next();
+    }
+
+    const duplicate = await this.constructor.exists({
+      externalId: this.externalId,
+      _id: { $ne: this._id },
+    });
+
+    if (duplicate) {
+      this.invalidate('externalId', 'externalId is already in use');
+    }
+
+    next();
+  } catch (err) {
+    next(err);
+  }
+});
+
+invoiceSchema.methods.getCanonicalIdentityKey = function () {
+  return this.externalId || String(this._id);
+};
+
+invoiceSchema.statics.isCanonicalExternalId = function (value) {
+  return isValidInvoiceExternalId(value);
+};
+
+invoiceSchema.statics.findByCanonicalIdentity = async function (identityKey, projection = null, options = {}) {
+  const normalized = String(identityKey || '').trim().toLowerCase();
+  if (!normalized) return null;
+  if (isValidInvoiceExternalId(normalized)) {
+    return this.findOne({ externalId: normalized }, projection, options);
+  }
+  if (isLikelyMongoObjectId(normalized)) {
+    return this.findById(normalized, projection, options);
+  }
+  return null;
+};
 
 module.exports = mongoose.model('Invoice', invoiceSchema);

--- a/backend/models/Order.js
+++ b/backend/models/Order.js
@@ -1,7 +1,25 @@
 const mongoose = require('mongoose');
+const {
+  generateOrderExternalId,
+  isLikelyMongoObjectId,
+  isValidOrderExternalId,
+} = require('../utils/externalId');
 
 const orderSchema = new mongoose.Schema(
   {
+    externalId: {
+      type: String,
+      unique: true,
+      sparse: true,
+      immutable: true,
+      lowercase: true,
+      trim: true,
+      select: false,
+      validate: {
+        validator: (value) => !value || isValidOrderExternalId(value),
+        message: 'Invalid canonical order external ID format',
+      },
+    },
     buyer: {
       type: mongoose.Schema.Types.ObjectId,
       ref: 'User',
@@ -105,7 +123,82 @@ const orderSchema = new mongoose.Schema(
       error: { type: String }
     }
   },
-  { timestamps: true }
+  {
+    timestamps: true,
+    toJSON: {
+      transform: (_doc, ret) => {
+        delete ret.externalId;
+        return ret;
+      },
+    },
+    toObject: {
+      transform: (_doc, ret) => {
+        delete ret.externalId;
+        return ret;
+      },
+    },
+  }
 );
+
+orderSchema.pre('validate', async function (next) {
+  try {
+    if (this.isNew && !this.externalId) {
+      this.externalId = generateOrderExternalId();
+      if (String(process.env.ORDER_EXTERNAL_ID_LOG || '').toLowerCase() === 'true') {
+        console.info(`[order-foundation] Assigned externalId=${this.externalId} for orderMongoId=${String(this._id)}`);
+      }
+    }
+
+    if (!this.isNew && this.isModified('externalId')) {
+      this.invalidate('externalId', 'externalId is immutable once assigned');
+      return next();
+    }
+
+    const needsUniquenessCheck = this.externalId && (this.isNew || this.isModified('externalId'));
+    if (!needsUniquenessCheck) {
+      return next();
+    }
+
+    const allowCheckWhileDisconnected =
+      String(process.env.ORDER_EXTERNAL_ID_TEST_UNIQUENESS || '').toLowerCase() === 'true';
+    const hasLiveDbConnection = this.constructor.db && this.constructor.db.readyState === 1;
+    if (!hasLiveDbConnection && !allowCheckWhileDisconnected) {
+      return next();
+    }
+
+    const duplicate = await this.constructor.exists({
+      externalId: this.externalId,
+      _id: { $ne: this._id },
+    });
+
+    if (duplicate) {
+      this.invalidate('externalId', 'externalId is already in use');
+    }
+
+    next();
+  } catch (err) {
+    next(err);
+  }
+});
+
+orderSchema.methods.getCanonicalIdentityKey = function () {
+  return this.externalId || String(this._id);
+};
+
+orderSchema.statics.isCanonicalExternalId = function (value) {
+  return isValidOrderExternalId(value);
+};
+
+orderSchema.statics.findByCanonicalIdentity = async function (identityKey, projection = null, options = {}) {
+  const normalized = String(identityKey || '').trim().toLowerCase();
+  if (!normalized) return null;
+  if (isValidOrderExternalId(normalized)) {
+    return this.findOne({ externalId: normalized }, projection, options);
+  }
+  if (isLikelyMongoObjectId(normalized)) {
+    return this.findById(normalized, projection, options);
+  }
+  return null;
+};
 
 module.exports = mongoose.model('Order', orderSchema);

--- a/backend/tests/unit/models/orderInvoice.foundation.test.js
+++ b/backend/tests/unit/models/orderInvoice.foundation.test.js
@@ -1,0 +1,217 @@
+const mongoose = require('mongoose');
+const Order = require('../../../models/Order');
+const Invoice = require('../../../models/Invoice');
+const {
+  generateInvoiceExternalId,
+  generateOrderExternalId,
+  isValidInvoiceExternalId,
+  isValidOrderExternalId,
+} = require('../../../utils/externalId');
+
+describe('NEW order/invoice external-ID foundation', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    jest.restoreAllMocks();
+  });
+
+  test('generates valid canonical order and invoice external ID formats', () => {
+    const orderExternalId = generateOrderExternalId();
+    const invoiceExternalId = generateInvoiceExternalId();
+
+    expect(isValidOrderExternalId(orderExternalId)).toBe(true);
+    expect(orderExternalId.startsWith('oid_')).toBe(true);
+
+    expect(isValidInvoiceExternalId(invoiceExternalId)).toBe(true);
+    expect(invoiceExternalId.startsWith('iid_')).toBe(true);
+
+    expect(isValidInvoiceExternalId(orderExternalId)).toBe(false);
+    expect(isValidOrderExternalId(invoiceExternalId)).toBe(false);
+  });
+
+  test('assigns externalId during validation for new order and invoice documents', async () => {
+    const order = new Order({
+      buyer: new mongoose.Types.ObjectId(),
+      total: 120,
+    });
+    const invoice = new Invoice({
+      vendor: new mongoose.Types.ObjectId(),
+      total: 120,
+      netAmount: 108,
+    });
+
+    await order.validate();
+    await invoice.validate();
+
+    expect(order.externalId).toBeTruthy();
+    expect(isValidOrderExternalId(order.externalId)).toBe(true);
+    expect(order.getCanonicalIdentityKey()).toBe(order.externalId);
+
+    expect(invoice.externalId).toBeTruthy();
+    expect(isValidInvoiceExternalId(invoice.externalId)).toBe(true);
+    expect(invoice.getCanonicalIdentityKey()).toBe(invoice.externalId);
+  });
+
+  test('hides canonical external IDs from serialized order and invoice payloads', async () => {
+    const order = new Order({
+      buyer: new mongoose.Types.ObjectId(),
+      total: 75,
+    });
+    const invoice = new Invoice({
+      vendor: new mongoose.Types.ObjectId(),
+      total: 75,
+      netAmount: 67,
+    });
+
+    await order.validate();
+    await invoice.validate();
+
+    expect(order.externalId).toBeTruthy();
+    expect(invoice.externalId).toBeTruthy();
+
+    const orderJson = order.toJSON();
+    const invoiceJson = invoice.toJSON();
+
+    expect(orderJson.externalId).toBeUndefined();
+    expect(invoiceJson.externalId).toBeUndefined();
+  });
+
+  test('findByCanonicalIdentity prefers externalId and falls back to legacy _id for order and invoice', async () => {
+    const orderExternalId = generateOrderExternalId();
+    const invoiceExternalId = generateInvoiceExternalId();
+    const orderLegacyId = new mongoose.Types.ObjectId().toString();
+    const invoiceLegacyId = new mongoose.Types.ObjectId().toString();
+
+    const orderFindOneSpy = jest.spyOn(Order, 'findOne').mockReturnValue('order-external-query');
+    const orderFindByIdSpy = jest.spyOn(Order, 'findById').mockReturnValue('order-legacy-query');
+
+    const invoiceFindOneSpy = jest.spyOn(Invoice, 'findOne').mockReturnValue('invoice-external-query');
+    const invoiceFindByIdSpy = jest.spyOn(Invoice, 'findById').mockReturnValue('invoice-legacy-query');
+
+    const orderByExternal = await Order.findByCanonicalIdentity(orderExternalId);
+    expect(orderByExternal).toBe('order-external-query');
+    expect(orderFindOneSpy).toHaveBeenCalledWith({ externalId: orderExternalId }, null, {});
+
+    const orderByLegacy = await Order.findByCanonicalIdentity(orderLegacyId);
+    expect(orderByLegacy).toBe('order-legacy-query');
+    expect(orderFindByIdSpy).toHaveBeenCalledWith(orderLegacyId, null, {});
+
+    const invoiceByExternal = await Invoice.findByCanonicalIdentity(invoiceExternalId);
+    expect(invoiceByExternal).toBe('invoice-external-query');
+    expect(invoiceFindOneSpy).toHaveBeenCalledWith({ externalId: invoiceExternalId }, null, {});
+
+    const invoiceByLegacy = await Invoice.findByCanonicalIdentity(invoiceLegacyId);
+    expect(invoiceByLegacy).toBe('invoice-legacy-query');
+    expect(invoiceFindByIdSpy).toHaveBeenCalledWith(invoiceLegacyId, null, {});
+
+    const invalidOrderIdentity = await Order.findByCanonicalIdentity('invalid-value');
+    expect(invalidOrderIdentity).toBeNull();
+
+    const invalidInvoiceIdentity = await Invoice.findByCanonicalIdentity('invalid-value');
+    expect(invalidInvoiceIdentity).toBeNull();
+  });
+
+  test('retains backward-safe canonical identity fallback for legacy documents without externalId', () => {
+    const legacyOrder = new Order({
+      _id: new mongoose.Types.ObjectId(),
+      buyer: new mongoose.Types.ObjectId(),
+      total: 50,
+    });
+    const legacyInvoice = new Invoice({
+      _id: new mongoose.Types.ObjectId(),
+      vendor: new mongoose.Types.ObjectId(),
+      total: 50,
+      netAmount: 45,
+    });
+
+    legacyOrder.externalId = undefined;
+    legacyInvoice.externalId = undefined;
+
+    expect(legacyOrder.getCanonicalIdentityKey()).toBe(String(legacyOrder._id));
+    expect(legacyInvoice.getCanonicalIdentityKey()).toBe(String(legacyInvoice._id));
+  });
+
+  test('rejects duplicate order externalId during validation', async () => {
+    process.env.ORDER_EXTERNAL_ID_TEST_UNIQUENESS = 'true';
+
+    const externalId = generateOrderExternalId();
+    const existsSpy = jest.spyOn(Order, 'exists').mockResolvedValue({ _id: new mongoose.Types.ObjectId() });
+
+    const order = new Order({
+      buyer: new mongoose.Types.ObjectId(),
+      total: 200,
+      externalId,
+    });
+
+    await expect(order.validate()).rejects.toThrow(mongoose.Error.ValidationError);
+    await order.validate().catch((err) => {
+      expect(err.errors.externalId.message).toMatch(/already in use/i);
+    });
+
+    expect(existsSpy).toHaveBeenCalledWith({
+      externalId,
+      _id: { $ne: order._id },
+    });
+  });
+
+  test('rejects duplicate invoice externalId during validation', async () => {
+    process.env.INVOICE_EXTERNAL_ID_TEST_UNIQUENESS = 'true';
+
+    const externalId = generateInvoiceExternalId();
+    const existsSpy = jest.spyOn(Invoice, 'exists').mockResolvedValue({ _id: new mongoose.Types.ObjectId() });
+
+    const invoice = new Invoice({
+      vendor: new mongoose.Types.ObjectId(),
+      total: 200,
+      netAmount: 170,
+      externalId,
+    });
+
+    await expect(invoice.validate()).rejects.toThrow(mongoose.Error.ValidationError);
+    await invoice.validate().catch((err) => {
+      expect(err.errors.externalId.message).toMatch(/already in use/i);
+    });
+
+    expect(existsSpy).toHaveBeenCalledWith({
+      externalId,
+      _id: { $ne: invoice._id },
+    });
+  });
+
+  test('rejects attempted order and invoice externalId mutation after initial assignment', async () => {
+    process.env.ORDER_EXTERNAL_ID_TEST_UNIQUENESS = 'true';
+    process.env.INVOICE_EXTERNAL_ID_TEST_UNIQUENESS = 'true';
+    jest.spyOn(Order, 'exists').mockResolvedValue(null);
+    jest.spyOn(Invoice, 'exists').mockResolvedValue(null);
+
+    const order = new Order({
+      buyer: new mongoose.Types.ObjectId(),
+      total: 99,
+    });
+    const invoice = new Invoice({
+      vendor: new mongoose.Types.ObjectId(),
+      total: 99,
+      netAmount: 89,
+    });
+
+    await order.validate();
+    await invoice.validate();
+
+    order.isNew = false;
+    invoice.isNew = false;
+
+    order.externalId = generateOrderExternalId();
+    invoice.externalId = generateInvoiceExternalId();
+
+    await expect(order.validate()).rejects.toThrow(mongoose.Error.ValidationError);
+    await order.validate().catch((err) => {
+      expect(err.errors.externalId.message).toMatch(/immutable/i);
+    });
+
+    await expect(invoice.validate()).rejects.toThrow(mongoose.Error.ValidationError);
+    await invoice.validate().catch((err) => {
+      expect(err.errors.externalId.message).toMatch(/immutable/i);
+    });
+  });
+});

--- a/backend/utils/externalId.js
+++ b/backend/utils/externalId.js
@@ -2,10 +2,18 @@ const crypto = require('crypto');
 
 const EXTERNAL_ID_PREFIX = 'uid';
 const PRODUCT_EXTERNAL_ID_PREFIX = 'pid';
+const ORDER_EXTERNAL_ID_PREFIX = 'oid';
+const INVOICE_EXTERNAL_ID_PREFIX = 'iid';
 const EXTERNAL_ID_BODY_LENGTH = 20;
 const EXTERNAL_ID_PATTERN = new RegExp(`^${EXTERNAL_ID_PREFIX}_[a-f0-9]{${EXTERNAL_ID_BODY_LENGTH}}$`);
 const PRODUCT_EXTERNAL_ID_PATTERN = new RegExp(
   `^${PRODUCT_EXTERNAL_ID_PREFIX}_[a-f0-9]{${EXTERNAL_ID_BODY_LENGTH}}$`
+);
+const ORDER_EXTERNAL_ID_PATTERN = new RegExp(
+  `^${ORDER_EXTERNAL_ID_PREFIX}_[a-f0-9]{${EXTERNAL_ID_BODY_LENGTH}}$`
+);
+const INVOICE_EXTERNAL_ID_PATTERN = new RegExp(
+  `^${INVOICE_EXTERNAL_ID_PREFIX}_[a-f0-9]{${EXTERNAL_ID_BODY_LENGTH}}$`
 );
 const LEGACY_MONGO_ID_PATTERN = /^[a-f0-9]{24}$/;
 
@@ -15,6 +23,14 @@ function generateExternalId() {
 
 function generateProductExternalId() {
   return `${PRODUCT_EXTERNAL_ID_PREFIX}_${crypto.randomBytes(10).toString('hex')}`;
+}
+
+function generateOrderExternalId() {
+  return `${ORDER_EXTERNAL_ID_PREFIX}_${crypto.randomBytes(10).toString('hex')}`;
+}
+
+function generateInvoiceExternalId() {
+  return `${INVOICE_EXTERNAL_ID_PREFIX}_${crypto.randomBytes(10).toString('hex')}`;
 }
 
 function generateVendorExternalId() {
@@ -31,6 +47,16 @@ function isValidProductExternalId(value) {
   return PRODUCT_EXTERNAL_ID_PATTERN.test(String(value).trim().toLowerCase());
 }
 
+function isValidOrderExternalId(value) {
+  if (!value) return false;
+  return ORDER_EXTERNAL_ID_PATTERN.test(String(value).trim().toLowerCase());
+}
+
+function isValidInvoiceExternalId(value) {
+  if (!value) return false;
+  return INVOICE_EXTERNAL_ID_PATTERN.test(String(value).trim().toLowerCase());
+}
+
 function isValidVendorExternalId(value) {
   return isValidExternalId(value);
 }
@@ -43,9 +69,13 @@ function isLikelyMongoObjectId(value) {
 module.exports = {
   generateExternalId,
   generateProductExternalId,
+  generateOrderExternalId,
+  generateInvoiceExternalId,
   generateVendorExternalId,
   isLikelyMongoObjectId,
   isValidExternalId,
   isValidProductExternalId,
+  isValidOrderExternalId,
+  isValidInvoiceExternalId,
   isValidVendorExternalId,
 };

--- a/docs/issues/new-order-invoice-external-id-foundation.md
+++ b/docs/issues/new-order-invoice-external-id-foundation.md
@@ -1,0 +1,49 @@
+Scope Lock — NEW: Order and invoice external-ID foundation
+
+**Intent**
+Establish canonical external-ID foundation for Order and Invoice entities at model and utility boundaries only.
+This slice is foundation-only and must not open read cutover, write cutover, or broad workflow changes.
+
+**NEW canonical path**
+
+* Introduce canonical external-ID primitives for Order and Invoice, aligned with the existing identity foundation pattern.
+* Define generation, normalization, validation, uniqueness, and immutability policy for Order and Invoice canonical IDs.
+* Add minimal model-level persistence and helper hooks so newly created Order and Invoice records can carry canonical external IDs and older records can be read safely without changing external runtime behavior.
+* Add focused unit and integration tests proving:
+
+  * ID shape validity
+  * Uniqueness guarantees
+  * stable linkage between legacy Mongo IDs and canonical external IDs
+  * backward-safe reads where canonical IDs may be absent on older data
+* Add non-invasive observability for canonical ID assignment and validation outcomes.
+
+**LEGACY path still present**
+
+* Mongo ObjectId remains authoritative for all live order and invoice read and write behavior in this slice.
+* Existing order creation, invoice generation, and API payload contracts remain unchanged.
+* No client-visible identifier contract changes are allowed.
+
+**TRANSITIONAL bridge path, if any**
+
+* Introduce minimal internal mapping helpers between legacy Mongo IDs and canonical Order/Invoice external IDs only where strictly required.
+* Transitional bridge is internal-only and additive.
+* No read cutover.
+* No dual-write expansion beyond existing mirror behavior.
+* No backfill jobs.
+* No migration orchestration.
+
+**Untouched surfaces**
+
+* No checkout, payment, shipment, returns, or analytics behavior changes.
+* No PostgreSQL read-path adoption.
+* No order mirror payload propagation changes in this slice.
+* No UI or E2E scope expansion beyond narrowly required foundation proof.
+* No schema-wide refactors outside strict Order/Invoice identity foundation surfaces.
+
+**Hard boundaries**
+
+* Restrict changes to model, identity utility, and focused tests required for Order/Invoice external-ID foundation.
+* Preserve runtime behavior and all public API contracts.
+* Do not introduce destination cutover logic.
+* Any MongoDB touch must be transition-enabling only for canonical Order/Invoice identity foundation, not Mongo modernization.
+* Keep PR draft until foundation validation evidence is complete.


### PR DESCRIPTION
Scope Lock — NEW: Order and invoice external-ID foundation

**Intent**
Establish canonical external-ID foundation for Order and Invoice entities at model and utility boundaries only.
This slice is foundation-only and must not open read cutover, write cutover, or broad workflow changes.

**NEW canonical path**

* Introduce canonical external-ID primitives for Order and Invoice, aligned with the existing identity foundation pattern.
* Define generation, normalization, validation, uniqueness, and immutability policy for Order and Invoice canonical IDs.
* Add minimal model-level persistence and helper hooks so newly created Order and Invoice records can carry canonical external IDs and older records can be read safely without changing external runtime behavior.
* Add focused unit and integration tests proving:

  * ID shape validity
  * Uniqueness guarantees
  * stable linkage between legacy Mongo IDs and canonical external IDs
  * backward-safe reads where canonical IDs may be absent on older data
* Add non-invasive observability for canonical ID assignment and validation outcomes.

**LEGACY path still present**

* Mongo ObjectId remains authoritative for all live order and invoice read and write behavior in this slice.
* Existing order creation, invoice generation, and API payload contracts remain unchanged.
* No client-visible identifier contract changes are allowed.

**TRANSITIONAL bridge path, if any**

* Introduce minimal internal mapping helpers between legacy Mongo IDs and canonical Order/Invoice external IDs only where strictly required.
* Transitional bridge is internal-only and additive.
* No read cutover.
* No dual-write expansion beyond existing mirror behavior.
* No backfill jobs.
* No migration orchestration.

**Untouched surfaces**

* No checkout, payment, shipment, returns, or analytics behavior changes.
* No PostgreSQL read-path adoption.
* No order mirror payload propagation changes in this slice.
* No UI or E2E scope expansion beyond narrowly required foundation proof.
* No schema-wide refactors outside strict Order/Invoice identity foundation surfaces.

**Hard boundaries**

* Restrict changes to model, identity utility, and focused tests required for Order/Invoice external-ID foundation.
* Preserve runtime behavior and all public API contracts.
* Do not introduce destination cutover logic.
* Any MongoDB touch must be transition-enabling only for canonical Order/Invoice identity foundation, not Mongo modernization.
* Keep PR draft until foundation validation evidence is complete.
