### PR TITLE
Scope Lock — TRAN: Order mirror canonical order/invoice identity propagation

### DIFF
--- a/backend/prisma/migrations/20260409153500_order_mirror_order_invoice_external_identity/migration.sql
+++ b/backend/prisma/migrations/20260409153500_order_mirror_order_invoice_external_identity/migration.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "OrderMirror"
+  ADD COLUMN "orderExternalId" TEXT;
+
+ALTER TABLE "OrderVendorMirror"
+  ADD COLUMN "invoiceExternalId" TEXT;
+
+CREATE INDEX "OrderMirror_orderExternalId_idx" ON "OrderMirror"("orderExternalId");
+CREATE INDEX "OrderVendorMirror_invoiceExternalId_idx" ON "OrderVendorMirror"("invoiceExternalId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -10,6 +10,7 @@ datasource db {
 model OrderMirror {
   id                 BigInt             @id @default(autoincrement())
   mongoId            String             @unique
+  orderExternalId    String?
   buyerMongoId       String
   buyerExternalId    String?
   status             String
@@ -31,6 +32,7 @@ model OrderMirror {
   vendors            OrderVendorMirror[]
 
   @@index([buyerMongoId])
+  @@index([orderExternalId])
   @@index([buyerExternalId])
   @@index([mirroredAt])
 }
@@ -44,6 +46,7 @@ model OrderVendorMirror {
   vendorName        String?
   vendorEmail       String?
   invoiceMongoId    String?
+  invoiceExternalId String?
   subtotal          Decimal               @db.Decimal(14, 2)
   discount          Decimal               @db.Decimal(14, 2)
   tax               Decimal               @db.Decimal(14, 2)
@@ -63,6 +66,7 @@ model OrderVendorMirror {
   @@index([orderMirrorId])
   @@index([vendorMongoId])
   @@index([vendorExternalId])
+  @@index([invoiceExternalId])
 }
 
 model OrderVendorItemMirror {

--- a/backend/scripts/postgres/checkOrderMirror.js
+++ b/backend/scripts/postgres/checkOrderMirror.js
@@ -4,12 +4,19 @@ const mongoose = require("mongoose");
 
 const { getPrismaClient, disconnectPrismaClient } = require("../../prisma/client");
 const Order = require("../../models/Order");
+const Invoice = require("../../models/Invoice");
 const {
   buildMirrorSummary,
   compareMirrorSummary,
   summarizeMirroredOrder,
 } = require("../../services/orderPostgresMirror");
-const { isValidExternalId, isValidProductExternalId, isValidVendorExternalId } = require("../../utils/externalId");
+const {
+  isValidExternalId,
+  isValidInvoiceExternalId,
+  isValidOrderExternalId,
+  isValidProductExternalId,
+  isValidVendorExternalId,
+} = require("../../utils/externalId");
 
 async function main() {
   const orderId = process.argv[2] || process.env.MONGO_ORDER_ID;
@@ -32,11 +39,39 @@ async function main() {
     useUnifiedTopology: true,
   });
 
-  const sourceOrder = await Order.findById(orderId).lean();
+  const sourceOrder = await Order.findById(orderId).select("+externalId").lean();
   if (!sourceOrder) {
     console.error(`[pg-mirror-check] No Mongo order found for ${orderId}`);
     process.exitCode = 4;
     return;
+  }
+
+  const sourceOrderExternalId =
+    sourceOrder && sourceOrder.externalId
+      ? String(sourceOrder.externalId).trim().toLowerCase()
+      : null;
+  const validSourceOrderExternalId =
+    sourceOrderExternalId && isValidOrderExternalId(sourceOrderExternalId) ? sourceOrderExternalId : null;
+
+  const sourceInvoiceIds = Array.from(
+    new Set(
+      (Array.isArray(sourceOrder.vendors) ? sourceOrder.vendors : [])
+        .map((vendor) => (vendor && vendor.invoiceId ? String(vendor.invoiceId) : ""))
+        .filter(Boolean)
+    )
+  );
+  let sourceInvoiceExternalIdByMongoId = new Map();
+  if (sourceInvoiceIds.length > 0) {
+    const sourceInvoices = await Invoice.find({ _id: { $in: sourceInvoiceIds } })
+      .select("_id externalId")
+      .lean();
+    sourceInvoiceExternalIdByMongoId = sourceInvoices.reduce((acc, invoice) => {
+      if (!invoice || !invoice._id || !invoice.externalId) return acc;
+      const normalized = String(invoice.externalId).trim().toLowerCase();
+      if (!isValidInvoiceExternalId(normalized)) return acc;
+      acc.set(String(invoice._id), normalized);
+      return acc;
+    }, new Map());
   }
 
   const mirrored = await prisma.orderMirror.findUnique({
@@ -60,11 +95,28 @@ async function main() {
   const mirroredSummary = summarizeMirroredOrder(mirrored);
   const discrepancies = compareMirrorSummary(sourceSummary, mirroredSummary);
   const richShape = {
+    orderCanonicalIdPresentWhenSourcePresent:
+      !validSourceOrderExternalId ||
+      (Boolean(mirrored.orderExternalId) && isValidOrderExternalId(mirrored.orderExternalId)),
     buyerCanonicalIdPresentWhenBuyerLinked:
       !mirrored.buyerMongoId || (Boolean(mirrored.buyerExternalId) && isValidExternalId(mirrored.buyerExternalId)),
     vendorNamesPresent: mirrored.vendors.every((vendor) => Boolean(vendor.vendorName)),
     vendorEmailsPresent: mirrored.vendors.every((vendor) => Boolean(vendor.vendorEmail)),
     invoiceLinksPresent: mirrored.vendors.every((vendor) => Boolean(vendor.invoiceMongoId)),
+    invoiceCanonicalIdsPresentWhenInvoiceLinked: mirrored.vendors.every(
+      (vendor) =>
+        !vendor.invoiceMongoId ||
+        (Boolean(vendor.invoiceExternalId) && isValidInvoiceExternalId(vendor.invoiceExternalId))
+    ),
+    invoiceCanonicalIdsPropagatedWhenSourcePresent: mirrored.vendors.every((vendor) => {
+      if (!vendor.invoiceMongoId) return true;
+      const sourceInvoiceExternalId = sourceInvoiceExternalIdByMongoId.get(String(vendor.invoiceMongoId));
+      if (!sourceInvoiceExternalId) return true;
+      return (
+        Boolean(vendor.invoiceExternalId) &&
+        String(vendor.invoiceExternalId).trim().toLowerCase() === sourceInvoiceExternalId
+      );
+    }),
     vendorCanonicalIdsPresent: mirrored.vendors.every(
       (vendor) => Boolean(vendor.vendorExternalId) && isValidVendorExternalId(vendor.vendorExternalId)
     ),

--- a/backend/scripts/postgres/runtimeProofOrderMirror.js
+++ b/backend/scripts/postgres/runtimeProofOrderMirror.js
@@ -11,7 +11,13 @@ const User = require("../../models/User");
 const Invoice = require("../../models/Invoice");
 const { getPrismaClient, disconnectPrismaClient } = require("../../prisma/client");
 const { summarizeMirroredOrder } = require("../../services/orderPostgresMirror");
-const { isValidExternalId, isValidProductExternalId, isValidVendorExternalId } = require("../../utils/externalId");
+const {
+  isValidExternalId,
+  isValidInvoiceExternalId,
+  isValidOrderExternalId,
+  isValidProductExternalId,
+  isValidVendorExternalId,
+} = require("../../utils/externalId");
 
 function rid(prefix) {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -91,7 +97,7 @@ async function run() {
   createdOrderId = String(res.body.order._id || "");
   assert.ok(createdOrderId, "Response order missing _id");
 
-  const mongoOrder = await Order.findById(createdOrderId).lean();
+  const mongoOrder = await Order.findById(createdOrderId).select("+externalId").lean();
   assert.ok(mongoOrder, "Mongo order was not persisted");
 
   const mirrored = await prisma.orderMirror.findUnique({
@@ -120,8 +126,19 @@ async function run() {
   assert.ok(mirrored.vendors.every((vendor) => vendor.vendorEmail), "Vendor emails should be mirrored");
   assert.ok(mirrored.vendors.every((vendor) => vendor.invoiceMongoId), "Invoice links should be mirrored");
   assert.ok(
+    !mongoOrder.externalId ||
+      (mirrored.orderExternalId && isValidOrderExternalId(mirrored.orderExternalId)),
+    "Order canonical external ID should be mirrored when source order has one"
+  );
+  assert.ok(
     !mirrored.buyerMongoId || (mirrored.buyerExternalId && isValidExternalId(mirrored.buyerExternalId)),
     "Buyer canonical external ID should be mirrored when buyer linkage exists"
+  );
+  assert.ok(
+    mirrored.vendors.every(
+      (vendor) => !vendor.invoiceMongoId || (vendor.invoiceExternalId && isValidInvoiceExternalId(vendor.invoiceExternalId))
+    ),
+    "Invoice canonical external IDs should be mirrored when invoice linkage exists"
   );
   assert.ok(
     mirrored.vendors.every((vendor) => vendor.vendorExternalId && isValidVendorExternalId(vendor.vendorExternalId)),

--- a/backend/services/orderPostgresMirror.js
+++ b/backend/services/orderPostgresMirror.js
@@ -1,7 +1,15 @@
 const { getPrismaClient } = require("../prisma/client");
+const Order = require("../models/Order");
 const User = require("../models/User");
 const Product = require("../models/Product");
-const { isValidExternalId, isValidProductExternalId, isValidVendorExternalId } = require("../utils/externalId");
+const Invoice = require("../models/Invoice");
+const {
+  isValidExternalId,
+  isValidInvoiceExternalId,
+  isValidOrderExternalId,
+  isValidProductExternalId,
+  isValidVendorExternalId,
+} = require("../utils/externalId");
 
 const VALID_MIRROR_MODES = new Set(["off", "best_effort"]);
 
@@ -88,6 +96,27 @@ async function resolveBuyerExternalId(order) {
   }
 }
 
+async function resolveOrderExternalId(order) {
+  const explicitOrderExternalId = normalizeExternalId(
+    order && (order.orderExternalId || order.orderCanonicalExternalId || order.externalId),
+    isValidOrderExternalId
+  );
+  if (explicitOrderExternalId) return explicitOrderExternalId;
+
+  const orderMongoId = order && order._id ? String(order._id) : "";
+  if (!orderMongoId) return null;
+
+  try {
+    const orderDoc = await Order.findById(orderMongoId).select("_id externalId").lean();
+    if (!orderDoc) return null;
+    return normalizeExternalId(orderDoc.externalId, isValidOrderExternalId);
+  } catch (error) {
+    const message = error && error.message ? error.message : String(error);
+    console.warn(`[orders-postgres-mirror] Canonical order identity enrichment fallback: ${message}`);
+    return null;
+  }
+}
+
 async function enrichVendorsWithCanonicalIdentity(vendors) {
   const normalizedVendors = Array.isArray(vendors) ? vendors : [];
   if (normalizedVendors.length === 0) return [];
@@ -107,23 +136,35 @@ async function enrichVendorsWithCanonicalIdentity(vendors) {
         .filter(Boolean)
     )
   );
+  const invoiceMongoIds = Array.from(
+    new Set(
+      normalizedVendors
+        .map((vendor) => (vendor && vendor.invoiceId ? String(vendor.invoiceId) : ""))
+        .filter(Boolean)
+    )
+  );
 
   let vendorExternalIdLookup = new Map();
   let productExternalIdLookup = new Map();
+  let invoiceExternalIdLookup = new Map();
 
-  if (vendorMongoIds.length > 0 || productMongoIds.length > 0) {
+  if (vendorMongoIds.length > 0 || productMongoIds.length > 0 || invoiceMongoIds.length > 0) {
     try {
-      const [vendorDocs, productDocs] = await Promise.all([
+      const [vendorDocs, productDocs, invoiceDocs] = await Promise.all([
         vendorMongoIds.length > 0
           ? User.find({ _id: { $in: vendorMongoIds } }).select("_id externalId").lean()
           : [],
         productMongoIds.length > 0
           ? Product.find({ _id: { $in: productMongoIds } }).select("_id externalId").lean()
           : [],
+        invoiceMongoIds.length > 0
+          ? Invoice.find({ _id: { $in: invoiceMongoIds } }).select("_id externalId").lean()
+          : [],
       ]);
 
       vendorExternalIdLookup = buildExternalIdLookup(vendorDocs, isValidVendorExternalId);
       productExternalIdLookup = buildExternalIdLookup(productDocs, isValidProductExternalId);
+      invoiceExternalIdLookup = buildExternalIdLookup(invoiceDocs, isValidInvoiceExternalId);
     } catch (error) {
       const message = error && error.message ? error.message : String(error);
       console.warn(`[orders-postgres-mirror] Canonical identity enrichment fallback: ${message}`);
@@ -132,9 +173,14 @@ async function enrichVendorsWithCanonicalIdentity(vendors) {
 
   return normalizedVendors.map((vendor) => {
     const vendorMongoId = vendor && vendor.vendorId ? String(vendor.vendorId) : "";
+    const invoiceMongoId = vendor && vendor.invoiceId ? String(vendor.invoiceId) : "";
     const explicitVendorExternalId = normalizeExternalId(
       vendor && (vendor.vendorExternalId || vendor.vendorCanonicalExternalId),
       isValidVendorExternalId
+    );
+    const explicitInvoiceExternalId = normalizeExternalId(
+      vendor && (vendor.invoiceExternalId || vendor.invoiceCanonicalExternalId),
+      isValidInvoiceExternalId
     );
 
     const products = Array.isArray(vendor && vendor.products) ? vendor.products : [];
@@ -154,6 +200,7 @@ async function enrichVendorsWithCanonicalIdentity(vendors) {
     return {
       ...(vendor || {}),
       vendorExternalId: explicitVendorExternalId || vendorExternalIdLookup.get(vendorMongoId) || null,
+      invoiceExternalId: explicitInvoiceExternalId || invoiceExternalIdLookup.get(invoiceMongoId) || null,
       products: enrichedProducts,
     };
   });
@@ -164,13 +211,15 @@ function buildVendorRows(vendors) {
 
   return vendors.map((vendor) => {
     const products = Array.isArray(vendor.products) ? vendor.products : [];
+    const invoiceMongoId = vendor.invoiceId ? String(vendor.invoiceId) : null;
 
     return {
       vendorMongoId: vendor.vendorId ? String(vendor.vendorId) : "",
       vendorExternalId: normalizeExternalId(vendor.vendorExternalId, isValidVendorExternalId),
       vendorName: vendor.vendorName || null,
       vendorEmail: vendor.vendorEmail || null,
-      invoiceMongoId: vendor.invoiceId ? String(vendor.invoiceId) : null,
+      invoiceMongoId,
+      invoiceExternalId: normalizeExternalId(vendor.invoiceExternalId, isValidInvoiceExternalId),
       subtotal: toMoney(vendor.subtotal),
       discount: toMoney(vendor.discount),
       tax: toMoney(vendor.tax),
@@ -250,6 +299,7 @@ function compareMirrorSummary(sourceSummary, mirroredSummary) {
 }
 
 async function buildMirrorPayload(order, vendors) {
+  const orderExternalId = await resolveOrderExternalId(order);
   const buyerExternalId = await resolveBuyerExternalId(order);
   const enrichedVendors = await enrichVendorsWithCanonicalIdentity(vendors);
   const sourceSummary = buildMirrorSummary(order, enrichedVendors);
@@ -257,6 +307,7 @@ async function buildMirrorPayload(order, vendors) {
   return {
     sourceSummary,
     data: {
+      orderExternalId,
       buyerMongoId: order.buyer ? String(order.buyer) : "",
       buyerExternalId,
       status: order.status || "pending",
@@ -359,6 +410,7 @@ module.exports = {
   enrichVendorsWithCanonicalIdentity,
   mirrorOrderCreationToPostgres,
   resolveBuyerExternalId,
+  resolveOrderExternalId,
   resolveOrdersPgMirrorMode,
   summarizeMirroredOrder,
 };

--- a/backend/tests/unit/services/orderPostgresMirror.test.js
+++ b/backend/tests/unit/services/orderPostgresMirror.test.js
@@ -5,9 +5,12 @@ const {
   compareMirrorSummary,
   enrichVendorsWithCanonicalIdentity,
   resolveBuyerExternalId,
+  resolveOrderExternalId,
   resolveOrdersPgMirrorMode,
   summarizeMirroredOrder,
 } = require("../../../services/orderPostgresMirror");
+const Order = require("../../../models/Order");
+const Invoice = require("../../../models/Invoice");
 const Product = require("../../../models/Product");
 const User = require("../../../models/User");
 
@@ -146,7 +149,7 @@ describe("orderPostgresMirror", () => {
     });
   });
 
-  test("enriches vendor/product canonical IDs from Mongo lookups", async () => {
+  test("enriches vendor/product/invoice canonical IDs from Mongo lookups", async () => {
     const userFindSpy = jest.spyOn(User, "find").mockReturnValue({
       select: () => ({
         lean: () => Promise.resolve([{ _id: "vendor-1", externalId: "uid_11111111111111111111" }]),
@@ -157,17 +160,25 @@ describe("orderPostgresMirror", () => {
         lean: () => Promise.resolve([{ _id: "product-1", externalId: "pid_11111111111111111111" }]),
       }),
     });
+    const invoiceFindSpy = jest.spyOn(Invoice, "find").mockReturnValue({
+      select: () => ({
+        lean: () => Promise.resolve([{ _id: "invoice-1", externalId: "iid_11111111111111111111" }]),
+      }),
+    });
 
     const enriched = await enrichVendorsWithCanonicalIdentity([
       {
         vendorId: "vendor-1",
+        invoiceId: "invoice-1",
         products: [{ product: "product-1", name: "Mirror Product", quantity: 1, price: 10 }],
       },
     ]);
 
     expect(userFindSpy).toHaveBeenCalledWith({ _id: { $in: ["vendor-1"] } });
     expect(productFindSpy).toHaveBeenCalledWith({ _id: { $in: ["product-1"] } });
+    expect(invoiceFindSpy).toHaveBeenCalledWith({ _id: { $in: ["invoice-1"] } });
     expect(enriched[0].vendorExternalId).toBe("uid_11111111111111111111");
+    expect(enriched[0].invoiceExternalId).toBe("iid_11111111111111111111");
     expect(enriched[0].products[0].productExternalId).toBe("pid_11111111111111111111");
   });
 
@@ -176,6 +187,8 @@ describe("orderPostgresMirror", () => {
       {
         vendorId: "vendor-1",
         vendorExternalId: "uid_aaaaaaaaaaaaaaaaaaaa",
+        invoiceId: "invoice-1",
+        invoiceExternalId: "iid_cccccccccccccccccccc",
         products: [
           {
             product: "product-1",
@@ -194,6 +207,7 @@ describe("orderPostgresMirror", () => {
     ]);
 
     expect(rows[0].vendorExternalId).toBe("uid_aaaaaaaaaaaaaaaaaaaa");
+    expect(rows[0].invoiceExternalId).toBe("iid_cccccccccccccccccccc");
     expect(rows[0].items.create[0].productExternalId).toBe("pid_bbbbbbbbbbbbbbbbbbbb");
     expect(rows[0].items.create[1].productExternalId).toBeNull();
   });
@@ -223,14 +237,43 @@ describe("orderPostgresMirror", () => {
     expect(result).toBe("uid_cccccccccccccccccccc");
   });
 
+  test("resolveOrderExternalId prefers explicit canonical order ID", async () => {
+    const findByIdSpy = jest.spyOn(Order, "findById");
+
+    const result = await resolveOrderExternalId({
+      _id: "order-1",
+      orderExternalId: "OID_AAAAAAAAAAAAAAAAAAAA",
+    });
+
+    expect(result).toBe("oid_aaaaaaaaaaaaaaaaaaaa");
+    expect(findByIdSpy).not.toHaveBeenCalled();
+  });
+
+  test("resolveOrderExternalId falls back to order lookup when explicit value missing", async () => {
+    const findByIdSpy = jest.spyOn(Order, "findById").mockReturnValue({
+      select: () => ({
+        lean: () => Promise.resolve({ _id: "order-1", externalId: "oid_cccccccccccccccccccc" }),
+      }),
+    });
+
+    const result = await resolveOrderExternalId({ _id: "order-1" });
+
+    expect(findByIdSpy).toHaveBeenCalledWith("order-1");
+    expect(result).toBe("oid_cccccccccccccccccccc");
+  });
+
   test("buildMirrorPayload keeps buyer canonical ID additive with absence fallback", async () => {
     jest.spyOn(User, "findById").mockReturnValue({
+      select: () => ({ lean: () => Promise.resolve(null) }),
+    });
+    jest.spyOn(Order, "findById").mockReturnValue({
       select: () => ({ lean: () => Promise.resolve(null) }),
     });
 
     const withExplicitBuyerId = await buildMirrorPayload(
       {
         _id: "order-1",
+        orderExternalId: "oid_eeeeeeeeeeeeeeeeeeee",
         buyer: "buyer-1",
         buyerExternalId: "uid_dddddddddddddddddddd",
         total: 20,
@@ -253,7 +296,9 @@ describe("orderPostgresMirror", () => {
 
     expect(withExplicitBuyerId.data.buyerMongoId).toBe("buyer-1");
     expect(withExplicitBuyerId.data.buyerExternalId).toBe("uid_dddddddddddddddddddd");
+    expect(withExplicitBuyerId.data.orderExternalId).toBe("oid_eeeeeeeeeeeeeeeeeeee");
     expect(withMissingBuyerId.data.buyerMongoId).toBe("buyer-2");
     expect(withMissingBuyerId.data.buyerExternalId).toBeNull();
+    expect(withMissingBuyerId.data.orderExternalId).toBeNull();
   });
 });

--- a/docs/issues/tran-order-mirror-canonical-order-invoice-identity-propagation.md
+++ b/docs/issues/tran-order-mirror-canonical-order-invoice-identity-propagation.md
@@ -1,0 +1,43 @@
+Scope Lock — TRAN: Order mirror canonical order/invoice identity propagation
+
+**Intent**
+Propagate canonical order and invoice identity into the existing order mirror transitional path only.
+This slice is bridge-only and must not introduce read cutover, write cutover, or broad workflow changes.
+
+**NEW canonical path**
+
+* Treat canonical order external identity and canonical invoice external identity from established foundations as source input only.
+* Do not redefine canonical identity formats, generation rules, or model contracts in this slice.
+* Consume existing canonical order/invoice identity primitives strictly for transitional mirror shaping and persistence.
+
+**LEGACY path still present**
+
+* Existing Mongo-backed order and invoice runtime remains authoritative.
+* Existing legacy Mongo ObjectId-based behavior remains authoritative for all live reads and writes.
+* No endpoint contract changes and no API payload semantic changes.
+
+**TRANSITIONAL bridge path, if any**
+
+* Update only transitional order mirror shaping and persistence to include canonical order identity and canonical invoice identity when available.
+* Preserve current mirror behavior when canonical order/invoice identity is absent.
+* Keep legacy mirror fields intact for backward compatibility.
+* Keep mirror writes additive and non-breaking.
+* No read cutover.
+* No dual-write expansion beyond the existing mirror path.
+* No backfill jobs.
+* No migration orchestration.
+
+**Untouched surfaces**
+
+* No checkout, payment, shipment, returns, or analytics behavior changes.
+* No product catalog or vendor-account business logic changes.
+* No UI or E2E scope expansion beyond proof updates strictly required by this field propagation.
+* No schema-wide refactors outside strictly required mirror payload fields and focused tests.
+
+**Hard boundaries**
+
+* Restrict changes to transitional mirror service/script/test surfaces required for canonical order/invoice identity propagation.
+* Add focused proof for additive mirror payload behavior only, including presence/absence handling and non-breaking invariants.
+* Preserve existing runtime behavior and public API contracts.
+* Do not introduce destination cutover logic.
+* MongoDB touches are allowed only where directly required to enable PostgreSQL transition proof for this field propagation; no broad Mongo stabilization.


### PR DESCRIPTION
Scope Lock — TRAN: Order mirror canonical order/invoice identity propagation

**Intent**
Propagate canonical order and invoice identity into the existing order mirror transitional path only.
This slice is bridge-only and must not introduce read cutover, write cutover, or broad workflow changes.

**NEW canonical path**

* Treat canonical order external identity and canonical invoice external identity from established foundations as source input only.
* Do not redefine canonical identity formats, generation rules, or model contracts in this slice.
* Consume existing canonical order/invoice identity primitives strictly for transitional mirror shaping and persistence.

**LEGACY path still present**

* Existing Mongo-backed order and invoice runtime remains authoritative.
* Existing legacy Mongo ObjectId-based behavior remains authoritative for all live reads and writes.
* No endpoint contract changes and no API payload semantic changes.

**TRANSITIONAL bridge path, if any**

* Update only transitional order mirror shaping and persistence to include canonical order identity and canonical invoice identity when available.
* Preserve current mirror behavior when canonical order/invoice identity is absent.
* Keep legacy mirror fields intact for backward compatibility.
* Keep mirror writes additive and non-breaking.
* No read cutover.
* No dual-write expansion beyond the existing mirror path.
* No backfill jobs.
* No migration orchestration.

**Untouched surfaces**

* No checkout, payment, shipment, returns, or analytics behavior changes.
* No product catalog or vendor-account business logic changes.
* No UI or E2E scope expansion beyond proof updates strictly required by this field propagation.
* No schema-wide refactors outside strictly required mirror payload fields and focused tests.

**Hard boundaries**

* Restrict changes to transitional mirror service/script/test surfaces required for canonical order/invoice identity propagation.
* Add focused proof for additive mirror payload behavior only, including presence/absence handling and non-breaking invariants.
* Preserve existing runtime behavior and public API contracts.
* Do not introduce destination cutover logic.
* MongoDB touches are allowed only where directly required to enable PostgreSQL transition proof for this field propagation; no broad Mongo stabilization.
