### PR TITLE
Scope Lock — TRAN: Order mirror canonical identity completeness proof hardening

### DIFF
--- a/backend/scripts/postgres/checkOrderMirror.js
+++ b/backend/scripts/postgres/checkOrderMirror.js
@@ -4,9 +4,10 @@ const mongoose = require("mongoose");
 
 const { getPrismaClient, disconnectPrismaClient } = require("../../prisma/client");
 const Order = require("../../models/Order");
-const Invoice = require("../../models/Invoice");
 const {
+  buildMirrorPayload,
   buildMirrorSummary,
+  compareCanonicalIdentityCompleteness,
   compareMirrorSummary,
   summarizeMirroredOrder,
 } = require("../../services/orderPostgresMirror");
@@ -46,34 +47,6 @@ async function main() {
     return;
   }
 
-  const sourceOrderExternalId =
-    sourceOrder && sourceOrder.externalId
-      ? String(sourceOrder.externalId).trim().toLowerCase()
-      : null;
-  const validSourceOrderExternalId =
-    sourceOrderExternalId && isValidOrderExternalId(sourceOrderExternalId) ? sourceOrderExternalId : null;
-
-  const sourceInvoiceIds = Array.from(
-    new Set(
-      (Array.isArray(sourceOrder.vendors) ? sourceOrder.vendors : [])
-        .map((vendor) => (vendor && vendor.invoiceId ? String(vendor.invoiceId) : ""))
-        .filter(Boolean)
-    )
-  );
-  let sourceInvoiceExternalIdByMongoId = new Map();
-  if (sourceInvoiceIds.length > 0) {
-    const sourceInvoices = await Invoice.find({ _id: { $in: sourceInvoiceIds } })
-      .select("_id externalId")
-      .lean();
-    sourceInvoiceExternalIdByMongoId = sourceInvoices.reduce((acc, invoice) => {
-      if (!invoice || !invoice._id || !invoice.externalId) return acc;
-      const normalized = String(invoice.externalId).trim().toLowerCase();
-      if (!isValidInvoiceExternalId(normalized)) return acc;
-      acc.set(String(invoice._id), normalized);
-      return acc;
-    }, new Map());
-  }
-
   const mirrored = await prisma.orderMirror.findUnique({
     where: { mongoId: String(orderId) },
     include: {
@@ -94,9 +67,12 @@ async function main() {
   const sourceSummary = buildMirrorSummary(sourceOrder, sourceOrder.vendors || []);
   const mirroredSummary = summarizeMirroredOrder(mirrored);
   const discrepancies = compareMirrorSummary(sourceSummary, mirroredSummary);
+  const { data: expectedMirrorData } = await buildMirrorPayload(sourceOrder, sourceOrder.vendors || []);
+  const identityDiscrepancies = compareCanonicalIdentityCompleteness(expectedMirrorData, mirrored);
   const richShape = {
+    canonicalIdentityCompleteness: identityDiscrepancies.length === 0,
     orderCanonicalIdPresentWhenSourcePresent:
-      !validSourceOrderExternalId ||
+      !expectedMirrorData.orderExternalId ||
       (Boolean(mirrored.orderExternalId) && isValidOrderExternalId(mirrored.orderExternalId)),
     buyerCanonicalIdPresentWhenBuyerLinked:
       !mirrored.buyerMongoId || (Boolean(mirrored.buyerExternalId) && isValidExternalId(mirrored.buyerExternalId)),
@@ -108,15 +84,8 @@ async function main() {
         !vendor.invoiceMongoId ||
         (Boolean(vendor.invoiceExternalId) && isValidInvoiceExternalId(vendor.invoiceExternalId))
     ),
-    invoiceCanonicalIdsPropagatedWhenSourcePresent: mirrored.vendors.every((vendor) => {
-      if (!vendor.invoiceMongoId) return true;
-      const sourceInvoiceExternalId = sourceInvoiceExternalIdByMongoId.get(String(vendor.invoiceMongoId));
-      if (!sourceInvoiceExternalId) return true;
-      return (
-        Boolean(vendor.invoiceExternalId) &&
-        String(vendor.invoiceExternalId).trim().toLowerCase() === sourceInvoiceExternalId
-      );
-    }),
+    invoiceCanonicalIdsPropagatedWhenSourcePresent:
+      !identityDiscrepancies.some((entry) => entry.includes("invoiceExternalId")),
     vendorCanonicalIdsPresent: mirrored.vendors.every(
       (vendor) => Boolean(vendor.vendorExternalId) && isValidVendorExternalId(vendor.vendorExternalId)
     ),
@@ -135,11 +104,16 @@ async function main() {
     sourceSummary,
     mirroredSummary,
     discrepancies,
+    identityDiscrepancies,
     richShape,
     mirroredAt: mirrored.mirroredAt,
   };
 
   console.log(JSON.stringify(summary, null, 2));
+
+  if (identityDiscrepancies.length > 0) {
+    process.exitCode = 5;
+  }
 }
 
 main()

--- a/backend/scripts/postgres/runtimeProofOrderMirror.js
+++ b/backend/scripts/postgres/runtimeProofOrderMirror.js
@@ -10,7 +10,11 @@ const Product = require("../../models/Product");
 const User = require("../../models/User");
 const Invoice = require("../../models/Invoice");
 const { getPrismaClient, disconnectPrismaClient } = require("../../prisma/client");
-const { summarizeMirroredOrder } = require("../../services/orderPostgresMirror");
+const {
+  buildMirrorPayload,
+  compareCanonicalIdentityCompleteness,
+  summarizeMirroredOrder,
+} = require("../../services/orderPostgresMirror");
 const {
   isValidExternalId,
   isValidInvoiceExternalId,
@@ -114,6 +118,13 @@ async function run() {
   assert.ok(mirrored, "Postgres mirror row was not written");
   assert.equal(String(mirrored.mongoId), createdOrderId, "Mirror mongoId mismatch");
   assert.equal(mirrored.vendors.length, mongoOrder.vendors.length, "Vendor mirror count mismatch");
+  const { data: expectedMirrorData } = await buildMirrorPayload(mongoOrder, mongoOrder.vendors || []);
+  const identityDiscrepancies = compareCanonicalIdentityCompleteness(expectedMirrorData, mirrored);
+  assert.equal(
+    identityDiscrepancies.length,
+    0,
+    `Canonical identity completeness mismatches: ${identityDiscrepancies.join(", ")}`
+  );
 
   const mirroredItemCount = mirrored.vendors.reduce((sum, v) => sum + v.items.length, 0);
   const mongoItemCount = (mongoOrder.vendors || []).reduce(
@@ -172,6 +183,7 @@ async function run() {
         runtimeProof: "ok",
         orderId: createdOrderId,
         responseInvariant,
+        identityDiscrepancyCount: identityDiscrepancies.length,
         mongoOrderStatus: mongoOrder.status,
         mirroredSummary: summarizeMirroredOrder(mirrored),
       },

--- a/backend/services/orderPostgresMirror.js
+++ b/backend/services/orderPostgresMirror.js
@@ -298,6 +298,122 @@ function compareMirrorSummary(sourceSummary, mirroredSummary) {
   return discrepancies;
 }
 
+function compareCanonicalField({ label, expectedValue, actualValue, validator, discrepancies }) {
+  const expected = normalizeExternalId(expectedValue, validator);
+  const actualRaw = actualValue === null || actualValue === undefined ? null : String(actualValue).trim().toLowerCase();
+  const actual = actualRaw && validator(actualRaw) ? actualRaw : null;
+
+  if (expected) {
+    if (actual !== expected) {
+      discrepancies.push(`${label}:${expected}->${actualRaw || "null"}`);
+    }
+    return;
+  }
+
+  if (actualRaw && !validator(actualRaw)) {
+    discrepancies.push(`${label}:invalid->${actualRaw}`);
+  }
+}
+
+function compareCanonicalIdentityCompleteness(expectedData, mirroredOrder) {
+  const discrepancies = [];
+
+  compareCanonicalField({
+    label: "orderExternalId",
+    expectedValue: expectedData && expectedData.orderExternalId,
+    actualValue: mirroredOrder && mirroredOrder.orderExternalId,
+    validator: isValidOrderExternalId,
+    discrepancies,
+  });
+
+  compareCanonicalField({
+    label: "buyerExternalId",
+    expectedValue: expectedData && expectedData.buyerExternalId,
+    actualValue: mirroredOrder && mirroredOrder.buyerExternalId,
+    validator: isValidExternalId,
+    discrepancies,
+  });
+
+  const sourceVendors =
+    expectedData && expectedData.vendors && Array.isArray(expectedData.vendors.create)
+      ? expectedData.vendors.create
+      : [];
+  const mirroredVendors = Array.isArray(mirroredOrder && mirroredOrder.vendors) ? mirroredOrder.vendors : [];
+
+  const mirroredBuckets = new Map();
+  mirroredVendors.forEach((vendor) => {
+    const key = `${String(vendor && vendor.vendorMongoId ? vendor.vendorMongoId : "")}::${
+      String(vendor && vendor.invoiceMongoId ? vendor.invoiceMongoId : "")
+    }`;
+    const bucket = mirroredBuckets.get(key) || [];
+    bucket.push(vendor || {});
+    mirroredBuckets.set(key, bucket);
+  });
+
+  sourceVendors.forEach((sourceVendor, vendorIndex) => {
+    const sourceKey = `${String(sourceVendor && sourceVendor.vendorMongoId ? sourceVendor.vendorMongoId : "")}::${
+      String(sourceVendor && sourceVendor.invoiceMongoId ? sourceVendor.invoiceMongoId : "")
+    }`;
+    const matchedBucket = mirroredBuckets.get(sourceKey) || [];
+    const mirroredVendor = matchedBucket.shift();
+
+    if (!mirroredVendor) {
+      discrepancies.push(`vendor[${vendorIndex}]:missing->${sourceKey}`);
+      return;
+    }
+
+    compareCanonicalField({
+      label: `vendor[${vendorIndex}].vendorExternalId`,
+      expectedValue: sourceVendor && sourceVendor.vendorExternalId,
+      actualValue: mirroredVendor.vendorExternalId,
+      validator: isValidVendorExternalId,
+      discrepancies,
+    });
+
+    compareCanonicalField({
+      label: `vendor[${vendorIndex}].invoiceExternalId`,
+      expectedValue: sourceVendor && sourceVendor.invoiceExternalId,
+      actualValue: mirroredVendor.invoiceExternalId,
+      validator: isValidInvoiceExternalId,
+      discrepancies,
+    });
+
+    const sourceItems = sourceVendor && sourceVendor.items && Array.isArray(sourceVendor.items.create)
+      ? sourceVendor.items.create
+      : [];
+    const mirroredItems = Array.isArray(mirroredVendor.items) ? mirroredVendor.items : [];
+    const mirroredItemBuckets = new Map();
+
+    mirroredItems.forEach((item) => {
+      const productMongoId = String(item && item.productMongoId ? item.productMongoId : "");
+      const bucket = mirroredItemBuckets.get(productMongoId) || [];
+      bucket.push(item || {});
+      mirroredItemBuckets.set(productMongoId, bucket);
+    });
+
+    sourceItems.forEach((sourceItem, itemIndex) => {
+      const productMongoId = String(sourceItem && sourceItem.productMongoId ? sourceItem.productMongoId : "");
+      const itemBucket = mirroredItemBuckets.get(productMongoId) || [];
+      const mirroredItem = itemBucket.shift();
+
+      if (!mirroredItem) {
+        discrepancies.push(`vendor[${vendorIndex}].item[${itemIndex}]:missing->${productMongoId}`);
+        return;
+      }
+
+      compareCanonicalField({
+        label: `vendor[${vendorIndex}].item[${itemIndex}].productExternalId`,
+        expectedValue: sourceItem && sourceItem.productExternalId,
+        actualValue: mirroredItem.productExternalId,
+        validator: isValidProductExternalId,
+        discrepancies,
+      });
+    });
+  });
+
+  return discrepancies;
+}
+
 async function buildMirrorPayload(order, vendors) {
   const orderExternalId = await resolveOrderExternalId(order);
   const buyerExternalId = await resolveBuyerExternalId(order);
@@ -382,6 +498,7 @@ async function mirrorOrderCreationToPostgres({ order, vendors }) {
 
     const mirroredSummary = summarizeMirroredOrder(mirrored);
     const discrepancies = compareMirrorSummary(sourceSummary, mirroredSummary);
+    const identityDiscrepancies = compareCanonicalIdentityCompleteness(data, mirrored);
 
     if (String(process.env.ORDERS_PG_MIRROR_LOG_SUCCESS || "").toLowerCase() === "true") {
       console.log(
@@ -394,6 +511,7 @@ async function mirrorOrderCreationToPostgres({ order, vendors }) {
       orderMongoId,
       summary: sourceSummary,
       discrepancies,
+      identityDiscrepancies,
     };
   } catch (error) {
     const message = error && error.message ? error.message : String(error);
@@ -406,6 +524,7 @@ module.exports = {
   buildMirrorPayload,
   buildMirrorSummary,
   buildVendorRows,
+  compareCanonicalIdentityCompleteness,
   compareMirrorSummary,
   enrichVendorsWithCanonicalIdentity,
   mirrorOrderCreationToPostgres,

--- a/backend/services/orderPostgresMirror.js
+++ b/backend/services/orderPostgresMirror.js
@@ -350,12 +350,29 @@ function compareCanonicalIdentityCompleteness(expectedData, mirroredOrder) {
     mirroredBuckets.set(key, bucket);
   });
 
+  function takeVendorMatch(sourceVendorMongoId, sourceInvoiceMongoId) {
+    const invoiceScopedKey = `${sourceVendorMongoId}::${sourceInvoiceMongoId}`;
+    if (sourceInvoiceMongoId) {
+      const exactBucket = mirroredBuckets.get(invoiceScopedKey) || [];
+      return exactBucket.shift() || null;
+    }
+
+    for (const [bucketKey, bucket] of mirroredBuckets.entries()) {
+      if (!Array.isArray(bucket) || bucket.length === 0) continue;
+      const [bucketVendorMongoId] = String(bucketKey).split("::");
+      if (bucketVendorMongoId === sourceVendorMongoId) {
+        return bucket.shift() || null;
+      }
+    }
+
+    return null;
+  }
+
   sourceVendors.forEach((sourceVendor, vendorIndex) => {
-    const sourceKey = `${String(sourceVendor && sourceVendor.vendorMongoId ? sourceVendor.vendorMongoId : "")}::${
-      String(sourceVendor && sourceVendor.invoiceMongoId ? sourceVendor.invoiceMongoId : "")
-    }`;
-    const matchedBucket = mirroredBuckets.get(sourceKey) || [];
-    const mirroredVendor = matchedBucket.shift();
+    const sourceVendorMongoId = String(sourceVendor && sourceVendor.vendorMongoId ? sourceVendor.vendorMongoId : "");
+    const sourceInvoiceMongoId = String(sourceVendor && sourceVendor.invoiceMongoId ? sourceVendor.invoiceMongoId : "");
+    const sourceKey = `${sourceVendorMongoId}::${sourceInvoiceMongoId}`;
+    const mirroredVendor = takeVendorMatch(sourceVendorMongoId, sourceInvoiceMongoId);
 
     if (!mirroredVendor) {
       discrepancies.push(`vendor[${vendorIndex}]:missing->${sourceKey}`);

--- a/backend/tests/unit/services/orderPostgresMirror.test.js
+++ b/backend/tests/unit/services/orderPostgresMirror.test.js
@@ -2,6 +2,7 @@ const {
   buildMirrorPayload,
   buildMirrorSummary,
   buildVendorRows,
+  compareCanonicalIdentityCompleteness,
   compareMirrorSummary,
   enrichVendorsWithCanonicalIdentity,
   resolveBuyerExternalId,
@@ -300,5 +301,107 @@ describe("orderPostgresMirror", () => {
     expect(withMissingBuyerId.data.buyerMongoId).toBe("buyer-2");
     expect(withMissingBuyerId.data.buyerExternalId).toBeNull();
     expect(withMissingBuyerId.data.orderExternalId).toBeNull();
+  });
+
+  test("compareCanonicalIdentityCompleteness reports strict source-to-mirror mismatches", () => {
+    const discrepancies = compareCanonicalIdentityCompleteness(
+      {
+        orderExternalId: "oid_aaaaaaaaaaaaaaaaaaaa",
+        buyerExternalId: "uid_bbbbbbbbbbbbbbbbbbbb",
+        vendors: {
+          create: [
+            {
+              vendorMongoId: "vendor-1",
+              invoiceMongoId: "invoice-1",
+              vendorExternalId: "uid_cccccccccccccccccccc",
+              invoiceExternalId: "iid_dddddddddddddddddddd",
+              items: {
+                create: [
+                  {
+                    productMongoId: "product-1",
+                    productExternalId: "pid_eeeeeeeeeeeeeeeeeeee",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      {
+        orderExternalId: "oid_ffffffffffffffffffff",
+        buyerExternalId: "uid_11111111111111111111",
+        vendors: [
+          {
+            vendorMongoId: "vendor-1",
+            invoiceMongoId: "invoice-1",
+            vendorExternalId: "uid_22222222222222222222",
+            invoiceExternalId: "iid_33333333333333333333",
+            items: [
+              {
+                productMongoId: "product-1",
+                productExternalId: "pid_44444444444444444444",
+              },
+            ],
+          },
+        ],
+      }
+    );
+
+    expect(discrepancies).toEqual(
+      expect.arrayContaining([
+        "orderExternalId:oid_aaaaaaaaaaaaaaaaaaaa->oid_ffffffffffffffffffff",
+        "buyerExternalId:uid_bbbbbbbbbbbbbbbbbbbb->uid_11111111111111111111",
+        "vendor[0].vendorExternalId:uid_cccccccccccccccccccc->uid_22222222222222222222",
+        "vendor[0].invoiceExternalId:iid_dddddddddddddddddddd->iid_33333333333333333333",
+        "vendor[0].item[0].productExternalId:pid_eeeeeeeeeeeeeeeeeeee->pid_44444444444444444444",
+      ])
+    );
+  });
+
+  test("compareCanonicalIdentityCompleteness keeps nullable/additive absence behavior non-breaking", () => {
+    const discrepancies = compareCanonicalIdentityCompleteness(
+      {
+        orderExternalId: null,
+        buyerExternalId: null,
+        vendors: {
+          create: [
+            {
+              vendorMongoId: "vendor-1",
+              invoiceMongoId: "invoice-1",
+              vendorExternalId: null,
+              invoiceExternalId: null,
+              items: {
+                create: [
+                  {
+                    productMongoId: "product-1",
+                    productExternalId: null,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      {
+        orderExternalId: "oid_aaaaaaaaaaaaaaaaaaaa",
+        buyerExternalId: "uid_bbbbbbbbbbbbbbbbbbbb",
+        vendors: [
+          {
+            vendorMongoId: "vendor-1",
+            invoiceMongoId: "invoice-1",
+            vendorExternalId: "uid_cccccccccccccccccccc",
+            invoiceExternalId: "iid_dddddddddddddddddddd",
+            items: [
+              {
+                productMongoId: "product-1",
+                productExternalId: "pid_eeeeeeeeeeeeeeeeeeee",
+              },
+            ],
+          },
+        ],
+      }
+    );
+
+    expect(discrepancies).toEqual([]);
   });
 });

--- a/backend/tests/unit/services/orderPostgresMirror.test.js
+++ b/backend/tests/unit/services/orderPostgresMirror.test.js
@@ -404,4 +404,88 @@ describe("orderPostgresMirror", () => {
 
     expect(discrepancies).toEqual([]);
   });
+
+  test("compareCanonicalIdentityCompleteness allows additive vendor invoice linkage when source invoice linkage is absent", () => {
+    const discrepancies = compareCanonicalIdentityCompleteness(
+      {
+        orderExternalId: null,
+        buyerExternalId: null,
+        vendors: {
+          create: [
+            {
+              vendorMongoId: "vendor-1",
+              invoiceMongoId: null,
+              vendorExternalId: null,
+              invoiceExternalId: null,
+              items: {
+                create: [
+                  {
+                    productMongoId: "product-1",
+                    productExternalId: null,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      {
+        orderExternalId: "oid_aaaaaaaaaaaaaaaaaaaa",
+        buyerExternalId: "uid_bbbbbbbbbbbbbbbbbbbb",
+        vendors: [
+          {
+            vendorMongoId: "vendor-1",
+            invoiceMongoId: "invoice-1",
+            vendorExternalId: "uid_cccccccccccccccccccc",
+            invoiceExternalId: "iid_dddddddddddddddddddd",
+            items: [
+              {
+                productMongoId: "product-1",
+                productExternalId: "pid_eeeeeeeeeeeeeeeeeeee",
+              },
+            ],
+          },
+        ],
+      }
+    );
+
+    expect(discrepancies).toEqual([]);
+  });
+
+  test("compareCanonicalIdentityCompleteness remains strict when source invoice linkage is present", () => {
+    const discrepancies = compareCanonicalIdentityCompleteness(
+      {
+        orderExternalId: null,
+        buyerExternalId: null,
+        vendors: {
+          create: [
+            {
+              vendorMongoId: "vendor-1",
+              invoiceMongoId: "invoice-expected",
+              vendorExternalId: null,
+              invoiceExternalId: null,
+              items: { create: [] },
+            },
+          ],
+        },
+      },
+      {
+        orderExternalId: null,
+        buyerExternalId: null,
+        vendors: [
+          {
+            vendorMongoId: "vendor-1",
+            invoiceMongoId: "invoice-actual",
+            vendorExternalId: null,
+            invoiceExternalId: null,
+            items: [],
+          },
+        ],
+      }
+    );
+
+    expect(discrepancies).toEqual([
+      "vendor[0]:missing->vendor-1::invoice-expected",
+    ]);
+  });
 });

--- a/docs/issues/tran-order-mirror-canonical-identity-completeness-proof-hardening.md
+++ b/docs/issues/tran-order-mirror-canonical-identity-completeness-proof-hardening.md
@@ -1,0 +1,53 @@
+Scope Lock — TRAN: Order mirror canonical identity completeness proof hardening
+
+**Intent**
+Harden proof and validation for canonical identity completeness in the existing order mirror transitional path only.
+This slice is proof-hardening only and must not introduce read cutover, write cutover, or broad workflow changes.
+
+**NEW canonical path**
+
+* Treat the existing canonical identity set as the source contract for mirror completeness:
+
+  * buyer external identity
+  * vendor external identity
+  * product external identity
+  * order external identity
+  * invoice external identity
+* Do not redefine canonical ID formats, generation rules, or model contracts in this slice.
+* Add focused proof assertions and validation logic that verify:
+
+  * canonical IDs are mirrored when present in source records
+  * nullable/additive behavior remains valid when canonical IDs are absent in source records
+  * canonical-to-legacy linkage invariants remain intact.
+
+**LEGACY path still present**
+
+* Existing Mongo-backed order and invoice runtime remains authoritative.
+* Existing legacy Mongo ObjectId-based behavior remains authoritative for all live reads and writes.
+* Legacy mirror identifier fields remain intact and required for backward compatibility.
+* No endpoint contract changes and no API payload semantic changes.
+
+**TRANSITIONAL bridge path, if any**
+
+* Update only transitional mirror proof/check/test and narrowly related mirror service validation surfaces needed to enforce canonical identity completeness invariants.
+* Keep bridge behavior additive and non-breaking.
+* No read cutover.
+* No dual-write expansion beyond the existing mirror path.
+* No backfill jobs.
+* No migration orchestration.
+
+**Untouched surfaces**
+
+* No checkout, payment, shipment, returns, or analytics behavior changes.
+* No product catalog or vendor-account business logic changes.
+* No UI or E2E scope expansion beyond proof-path checks required for this hardening.
+* No schema-wide refactors.
+* No destination read-path adoption.
+
+**Hard boundaries**
+
+* Restrict changes to transitional mirror service validation, runtime proof scripts, check scripts, and focused tests required for identity-completeness hardening.
+* Preserve existing runtime behavior and public API contracts.
+* Do not introduce destination cutover logic.
+* MongoDB touches are allowed only where directly required to validate PostgreSQL transition proof for identity-completeness checks; no broad Mongo stabilization.
+* Keep PR in Draft until executed CI proof evidence is complete and green.


### PR DESCRIPTION
Scope Lock — TRAN: Order mirror canonical identity completeness proof hardening

**Intent**
Harden proof and validation for canonical identity completeness in the existing order mirror transitional path only.
This slice is proof-hardening only and must not introduce read cutover, write cutover, or broad workflow changes.

**NEW canonical path**

* Treat the existing canonical identity set as the source contract for mirror completeness:

  * buyer external identity
  * vendor external identity
  * product external identity
  * order external identity
  * invoice external identity
* Do not redefine canonical ID formats, generation rules, or model contracts in this slice.
* Add focused proof assertions and validation logic that verify:

  * canonical IDs are mirrored when present in source records
  * nullable/additive behavior remains valid when canonical IDs are absent in source records
  * canonical-to-legacy linkage invariants remain intact.

**LEGACY path still present**

* Existing Mongo-backed order and invoice runtime remains authoritative.
* Existing legacy Mongo ObjectId-based behavior remains authoritative for all live reads and writes.
* Legacy mirror identifier fields remain intact and required for backward compatibility.
* No endpoint contract changes and no API payload semantic changes.

**TRANSITIONAL bridge path, if any**

* Update only transitional mirror proof/check/test and narrowly related mirror service validation surfaces needed to enforce canonical identity completeness invariants.
* Keep bridge behavior additive and non-breaking.
* No read cutover.
* No dual-write expansion beyond the existing mirror path.
* No backfill jobs.
* No migration orchestration.

**Untouched surfaces**

* No checkout, payment, shipment, returns, or analytics behavior changes.
* No product catalog or vendor-account business logic changes.
* No UI or E2E scope expansion beyond proof-path checks required for this hardening.
* No schema-wide refactors.
* No destination read-path adoption.

**Hard boundaries**

* Restrict changes to transitional mirror service validation, runtime proof scripts, check scripts, and focused tests required for identity-completeness hardening.
* Preserve existing runtime behavior and public API contracts.
* Do not introduce destination cutover logic.
* MongoDB touches are allowed only where directly required to validate PostgreSQL transition proof for identity-completeness checks; no broad Mongo stabilization.
* Keep PR in Draft until executed CI proof evidence is complete and green.
