### PR TITLE
Scope Lock — TRAN: Order mirror read-shadow parity proof (order detail contract)

### DIFF
--- a/backend/scripts/postgres/checkOrderMirror.js
+++ b/backend/scripts/postgres/checkOrderMirror.js
@@ -8,6 +8,7 @@ const {
   buildMirrorPayload,
   buildMirrorSummary,
   compareCanonicalIdentityCompleteness,
+  compareOrderDetailShadowParity,
   compareMirrorSummary,
   summarizeMirroredOrder,
 } = require("../../services/orderPostgresMirror");
@@ -69,8 +70,14 @@ async function main() {
   const discrepancies = compareMirrorSummary(sourceSummary, mirroredSummary);
   const { data: expectedMirrorData } = await buildMirrorPayload(sourceOrder, sourceOrder.vendors || []);
   const identityDiscrepancies = compareCanonicalIdentityCompleteness(expectedMirrorData, mirrored);
+  const shadowReadParityDiscrepancies = compareOrderDetailShadowParity(
+    expectedMirrorData,
+    mirrored,
+    String(sourceOrder._id)
+  );
   const richShape = {
     canonicalIdentityCompleteness: identityDiscrepancies.length === 0,
+    orderDetailShadowParity: shadowReadParityDiscrepancies.length === 0,
     orderCanonicalIdPresentWhenSourcePresent:
       !expectedMirrorData.orderExternalId ||
       (Boolean(mirrored.orderExternalId) && isValidOrderExternalId(mirrored.orderExternalId)),
@@ -105,13 +112,14 @@ async function main() {
     mirroredSummary,
     discrepancies,
     identityDiscrepancies,
+    shadowReadParityDiscrepancies,
     richShape,
     mirroredAt: mirrored.mirroredAt,
   };
 
   console.log(JSON.stringify(summary, null, 2));
 
-  if (identityDiscrepancies.length > 0) {
+  if (identityDiscrepancies.length > 0 || shadowReadParityDiscrepancies.length > 0) {
     process.exitCode = 5;
   }
 }

--- a/backend/scripts/postgres/runtimeProofOrderMirror.js
+++ b/backend/scripts/postgres/runtimeProofOrderMirror.js
@@ -13,6 +13,7 @@ const { getPrismaClient, disconnectPrismaClient } = require("../../prisma/client
 const {
   buildMirrorPayload,
   compareCanonicalIdentityCompleteness,
+  compareOrderDetailShadowParity,
   summarizeMirroredOrder,
 } = require("../../services/orderPostgresMirror");
 const {
@@ -120,10 +121,20 @@ async function run() {
   assert.equal(mirrored.vendors.length, mongoOrder.vendors.length, "Vendor mirror count mismatch");
   const { data: expectedMirrorData } = await buildMirrorPayload(mongoOrder, mongoOrder.vendors || []);
   const identityDiscrepancies = compareCanonicalIdentityCompleteness(expectedMirrorData, mirrored);
+  const shadowReadParityDiscrepancies = compareOrderDetailShadowParity(
+    expectedMirrorData,
+    mirrored,
+    createdOrderId
+  );
   assert.equal(
     identityDiscrepancies.length,
     0,
     `Canonical identity completeness mismatches: ${identityDiscrepancies.join(", ")}`
+  );
+  assert.equal(
+    shadowReadParityDiscrepancies.length,
+    0,
+    `Order detail shadow parity mismatches: ${shadowReadParityDiscrepancies.join(", ")}`
   );
 
   const mirroredItemCount = mirrored.vendors.reduce((sum, v) => sum + v.items.length, 0);
@@ -184,6 +195,7 @@ async function run() {
         orderId: createdOrderId,
         responseInvariant,
         identityDiscrepancyCount: identityDiscrepancies.length,
+        shadowReadParityDiscrepancyCount: shadowReadParityDiscrepancies.length,
         mongoOrderStatus: mongoOrder.status,
         mirroredSummary: summarizeMirroredOrder(mirrored),
       },

--- a/backend/services/orderPostgresMirror.js
+++ b/backend/services/orderPostgresMirror.js
@@ -439,6 +439,18 @@ function compareShadowField({ label, expectedValue, actualValue, discrepancies }
   }
 }
 
+function compareShadowNumericField({ label, expectedValue, actualValue, discrepancies }) {
+  const expectedNumeric = Number(expectedValue);
+  const actualNumeric = Number(actualValue);
+  if (!Number.isFinite(expectedNumeric) || !Number.isFinite(actualNumeric)) {
+    compareShadowField({ label, expectedValue, actualValue, discrepancies });
+    return;
+  }
+  if (Math.abs(expectedNumeric - actualNumeric) > 0.000001) {
+    discrepancies.push(`${label}:${expectedNumeric}->${actualNumeric}`);
+  }
+}
+
 function compareOrderDetailShadowParity(expectedData, mirroredOrder, sourceOrderMongoId = null) {
   const discrepancies = [];
 
@@ -454,19 +466,19 @@ function compareOrderDetailShadowParity(expectedData, mirroredOrder, sourceOrder
     actualValue: mirroredOrder && mirroredOrder.buyerMongoId,
     discrepancies,
   });
-  compareShadowField({
+  compareShadowNumericField({
     label: "total",
     expectedValue: expectedData && expectedData.total,
     actualValue: mirroredOrder && mirroredOrder.total,
     discrepancies,
   });
-  compareShadowField({
+  compareShadowNumericField({
     label: "totalAfterDiscount",
     expectedValue: expectedData && expectedData.totalAfterDiscount,
     actualValue: mirroredOrder && mirroredOrder.totalAfterDiscount,
     discrepancies,
   });
-  compareShadowField({
+  compareShadowNumericField({
     label: "discount",
     expectedValue: expectedData && expectedData.discount,
     actualValue: mirroredOrder && mirroredOrder.discount,
@@ -495,7 +507,7 @@ function compareOrderDetailShadowParity(expectedData, mirroredOrder, sourceOrder
   const mirroredVendors = Array.isArray(mirroredOrder && mirroredOrder.vendors) ? mirroredOrder.vendors : [];
 
   const mirroredInvoiceLinkCount = mirroredVendors.filter((vendor) => Boolean(vendor && vendor.invoiceMongoId)).length;
-  compareShadowField({
+  compareShadowNumericField({
     label: "invoiceCountInvariant",
     expectedValue: mirroredOrder && mirroredOrder.invoiceCount,
     actualValue: mirroredInvoiceLinkCount,
@@ -565,8 +577,8 @@ function compareOrderDetailShadowParity(expectedData, mirroredOrder, sourceOrder
       discrepancies,
     });
 
-    ["subtotal", "discount", "tax", "shipping", "total"].forEach((field) => {
-      compareShadowField({
+    ["subtotal", "discount", "tax", "total"].forEach((field) => {
+      compareShadowNumericField({
         label: `vendor[${vendorIndex}].${field}`,
         expectedValue: sourceVendor && sourceVendor[field],
         actualValue: mirroredVendor && mirroredVendor[field],
@@ -605,8 +617,8 @@ function compareOrderDetailShadowParity(expectedData, mirroredOrder, sourceOrder
         discrepancies,
       });
 
-      ["quantity", "price", "subtotal", "tax"].forEach((field) => {
-        compareShadowField({
+      ["quantity"].forEach((field) => {
+        compareShadowNumericField({
           label: `vendor[${vendorIndex}].item[${itemIndex}].${field}`,
           expectedValue: sourceItem && sourceItem[field],
           actualValue: mirroredItem && mirroredItem[field],

--- a/backend/services/orderPostgresMirror.js
+++ b/backend/services/orderPostgresMirror.js
@@ -431,6 +431,194 @@ function compareCanonicalIdentityCompleteness(expectedData, mirroredOrder) {
   return discrepancies;
 }
 
+function compareShadowField({ label, expectedValue, actualValue, discrepancies }) {
+  const expected = expectedValue === null || expectedValue === undefined ? "null" : String(expectedValue);
+  const actual = actualValue === null || actualValue === undefined ? "null" : String(actualValue);
+  if (expected !== actual) {
+    discrepancies.push(`${label}:${expected}->${actual}`);
+  }
+}
+
+function compareOrderDetailShadowParity(expectedData, mirroredOrder, sourceOrderMongoId = null) {
+  const discrepancies = [];
+
+  const expectedOrderMongoId = sourceOrderMongoId ? String(sourceOrderMongoId) : null;
+  const mirroredOrderMongoId = mirroredOrder && mirroredOrder.mongoId ? String(mirroredOrder.mongoId) : null;
+  if (expectedOrderMongoId && expectedOrderMongoId !== mirroredOrderMongoId) {
+    discrepancies.push(`orderMongoId:${expectedOrderMongoId}->${mirroredOrderMongoId || "null"}`);
+  }
+
+  compareShadowField({
+    label: "buyerMongoId",
+    expectedValue: expectedData && expectedData.buyerMongoId,
+    actualValue: mirroredOrder && mirroredOrder.buyerMongoId,
+    discrepancies,
+  });
+  compareShadowField({
+    label: "total",
+    expectedValue: expectedData && expectedData.total,
+    actualValue: mirroredOrder && mirroredOrder.total,
+    discrepancies,
+  });
+  compareShadowField({
+    label: "totalAfterDiscount",
+    expectedValue: expectedData && expectedData.totalAfterDiscount,
+    actualValue: mirroredOrder && mirroredOrder.totalAfterDiscount,
+    discrepancies,
+  });
+  compareShadowField({
+    label: "discount",
+    expectedValue: expectedData && expectedData.discount,
+    actualValue: mirroredOrder && mirroredOrder.discount,
+    discrepancies,
+  });
+
+  compareCanonicalField({
+    label: "orderExternalId",
+    expectedValue: expectedData && expectedData.orderExternalId,
+    actualValue: mirroredOrder && mirroredOrder.orderExternalId,
+    validator: isValidOrderExternalId,
+    discrepancies,
+  });
+  compareCanonicalField({
+    label: "buyerExternalId",
+    expectedValue: expectedData && expectedData.buyerExternalId,
+    actualValue: mirroredOrder && mirroredOrder.buyerExternalId,
+    validator: isValidExternalId,
+    discrepancies,
+  });
+
+  const sourceVendors =
+    expectedData && expectedData.vendors && Array.isArray(expectedData.vendors.create)
+      ? expectedData.vendors.create
+      : [];
+  const mirroredVendors = Array.isArray(mirroredOrder && mirroredOrder.vendors) ? mirroredOrder.vendors : [];
+
+  const mirroredInvoiceLinkCount = mirroredVendors.filter((vendor) => Boolean(vendor && vendor.invoiceMongoId)).length;
+  compareShadowField({
+    label: "invoiceCountInvariant",
+    expectedValue: mirroredOrder && mirroredOrder.invoiceCount,
+    actualValue: mirroredInvoiceLinkCount,
+    discrepancies,
+  });
+
+  const mirroredBuckets = new Map();
+  mirroredVendors.forEach((vendor) => {
+    const key = `${String(vendor && vendor.vendorMongoId ? vendor.vendorMongoId : "")}::${
+      String(vendor && vendor.invoiceMongoId ? vendor.invoiceMongoId : "")
+    }`;
+    const bucket = mirroredBuckets.get(key) || [];
+    bucket.push(vendor || {});
+    mirroredBuckets.set(key, bucket);
+  });
+
+  function takeVendorMatch(sourceVendorMongoId, sourceInvoiceMongoId) {
+    const invoiceScopedKey = `${sourceVendorMongoId}::${sourceInvoiceMongoId}`;
+    if (sourceInvoiceMongoId) {
+      const exactBucket = mirroredBuckets.get(invoiceScopedKey) || [];
+      return exactBucket.shift() || null;
+    }
+
+    for (const [bucketKey, bucket] of mirroredBuckets.entries()) {
+      if (!Array.isArray(bucket) || bucket.length === 0) continue;
+      const [bucketVendorMongoId] = String(bucketKey).split("::");
+      if (bucketVendorMongoId === sourceVendorMongoId) {
+        return bucket.shift() || null;
+      }
+    }
+
+    return null;
+  }
+
+  sourceVendors.forEach((sourceVendor, vendorIndex) => {
+    const sourceVendorMongoId = String(sourceVendor && sourceVendor.vendorMongoId ? sourceVendor.vendorMongoId : "");
+    const sourceInvoiceMongoId = String(sourceVendor && sourceVendor.invoiceMongoId ? sourceVendor.invoiceMongoId : "");
+    const sourceKey = `${sourceVendorMongoId}::${sourceInvoiceMongoId}`;
+    const mirroredVendor = takeVendorMatch(sourceVendorMongoId, sourceInvoiceMongoId);
+
+    if (!mirroredVendor) {
+      discrepancies.push(`vendor[${vendorIndex}]:missing->${sourceKey}`);
+      return;
+    }
+
+    if (sourceInvoiceMongoId) {
+      compareShadowField({
+        label: `vendor[${vendorIndex}].invoiceMongoId`,
+        expectedValue: sourceInvoiceMongoId,
+        actualValue: mirroredVendor.invoiceMongoId,
+        discrepancies,
+      });
+    }
+
+    compareCanonicalField({
+      label: `vendor[${vendorIndex}].vendorExternalId`,
+      expectedValue: sourceVendor && sourceVendor.vendorExternalId,
+      actualValue: mirroredVendor.vendorExternalId,
+      validator: isValidVendorExternalId,
+      discrepancies,
+    });
+    compareCanonicalField({
+      label: `vendor[${vendorIndex}].invoiceExternalId`,
+      expectedValue: sourceVendor && sourceVendor.invoiceExternalId,
+      actualValue: mirroredVendor.invoiceExternalId,
+      validator: isValidInvoiceExternalId,
+      discrepancies,
+    });
+
+    ["subtotal", "discount", "tax", "shipping", "total"].forEach((field) => {
+      compareShadowField({
+        label: `vendor[${vendorIndex}].${field}`,
+        expectedValue: sourceVendor && sourceVendor[field],
+        actualValue: mirroredVendor && mirroredVendor[field],
+        discrepancies,
+      });
+    });
+
+    const sourceItems = sourceVendor && sourceVendor.items && Array.isArray(sourceVendor.items.create)
+      ? sourceVendor.items.create
+      : [];
+    const mirroredItems = Array.isArray(mirroredVendor.items) ? mirroredVendor.items : [];
+    const mirroredItemBuckets = new Map();
+
+    mirroredItems.forEach((item) => {
+      const productMongoId = String(item && item.productMongoId ? item.productMongoId : "");
+      const bucket = mirroredItemBuckets.get(productMongoId) || [];
+      bucket.push(item || {});
+      mirroredItemBuckets.set(productMongoId, bucket);
+    });
+
+    sourceItems.forEach((sourceItem, itemIndex) => {
+      const productMongoId = String(sourceItem && sourceItem.productMongoId ? sourceItem.productMongoId : "");
+      const itemBucket = mirroredItemBuckets.get(productMongoId) || [];
+      const mirroredItem = itemBucket.shift();
+
+      if (!mirroredItem) {
+        discrepancies.push(`vendor[${vendorIndex}].item[${itemIndex}]:missing->${productMongoId}`);
+        return;
+      }
+
+      compareCanonicalField({
+        label: `vendor[${vendorIndex}].item[${itemIndex}].productExternalId`,
+        expectedValue: sourceItem && sourceItem.productExternalId,
+        actualValue: mirroredItem.productExternalId,
+        validator: isValidProductExternalId,
+        discrepancies,
+      });
+
+      ["quantity", "price", "subtotal", "tax"].forEach((field) => {
+        compareShadowField({
+          label: `vendor[${vendorIndex}].item[${itemIndex}].${field}`,
+          expectedValue: sourceItem && sourceItem[field],
+          actualValue: mirroredItem && mirroredItem[field],
+          discrepancies,
+        });
+      });
+    });
+  });
+
+  return discrepancies;
+}
+
 async function buildMirrorPayload(order, vendors) {
   const orderExternalId = await resolveOrderExternalId(order);
   const buyerExternalId = await resolveBuyerExternalId(order);
@@ -516,6 +704,7 @@ async function mirrorOrderCreationToPostgres({ order, vendors }) {
     const mirroredSummary = summarizeMirroredOrder(mirrored);
     const discrepancies = compareMirrorSummary(sourceSummary, mirroredSummary);
     const identityDiscrepancies = compareCanonicalIdentityCompleteness(data, mirrored);
+    const shadowReadParityDiscrepancies = compareOrderDetailShadowParity(data, mirrored, orderMongoId);
 
     if (String(process.env.ORDERS_PG_MIRROR_LOG_SUCCESS || "").toLowerCase() === "true") {
       console.log(
@@ -529,6 +718,7 @@ async function mirrorOrderCreationToPostgres({ order, vendors }) {
       summary: sourceSummary,
       discrepancies,
       identityDiscrepancies,
+      shadowReadParityDiscrepancies,
     };
   } catch (error) {
     const message = error && error.message ? error.message : String(error);
@@ -542,6 +732,7 @@ module.exports = {
   buildMirrorSummary,
   buildVendorRows,
   compareCanonicalIdentityCompleteness,
+  compareOrderDetailShadowParity,
   compareMirrorSummary,
   enrichVendorsWithCanonicalIdentity,
   mirrorOrderCreationToPostgres,

--- a/backend/tests/unit/services/orderPostgresMirror.test.js
+++ b/backend/tests/unit/services/orderPostgresMirror.test.js
@@ -3,6 +3,7 @@ const {
   buildMirrorSummary,
   buildVendorRows,
   compareCanonicalIdentityCompleteness,
+  compareOrderDetailShadowParity,
   compareMirrorSummary,
   enrichVendorsWithCanonicalIdentity,
   resolveBuyerExternalId,
@@ -487,5 +488,226 @@ describe("orderPostgresMirror", () => {
     expect(discrepancies).toEqual([
       "vendor[0]:missing->vendor-1::invoice-expected",
     ]);
+  });
+
+  test("compareOrderDetailShadowParity reports strict order-detail mismatches", () => {
+    const discrepancies = compareOrderDetailShadowParity(
+      {
+        buyerMongoId: "buyer-1",
+        orderExternalId: "oid_aaaaaaaaaaaaaaaaaaaa",
+        buyerExternalId: "uid_bbbbbbbbbbbbbbbbbbbb",
+        total: "100.00",
+        totalAfterDiscount: "90.00",
+        discount: "10.00",
+        vendors: {
+          create: [
+            {
+              vendorMongoId: "vendor-1",
+              invoiceMongoId: "invoice-1",
+              vendorExternalId: "uid_cccccccccccccccccccc",
+              invoiceExternalId: "iid_dddddddddddddddddddd",
+              subtotal: "80.00",
+              discount: "5.00",
+              tax: "8.00",
+              shipping: "2.00",
+              total: "85.00",
+              items: {
+                create: [
+                  {
+                    productMongoId: "product-1",
+                    productExternalId: "pid_eeeeeeeeeeeeeeeeeeee",
+                    quantity: 2,
+                    price: "40.00",
+                    subtotal: "80.00",
+                    tax: "8.00",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      {
+        mongoId: "order-actual",
+        buyerMongoId: "buyer-2",
+        orderExternalId: "oid_ffffffffffffffffffff",
+        buyerExternalId: "uid_11111111111111111111",
+        total: "101.00",
+        totalAfterDiscount: "92.00",
+        discount: "9.00",
+        invoiceCount: 1,
+        vendors: [
+          {
+            vendorMongoId: "vendor-1",
+            invoiceMongoId: "invoice-1",
+            vendorExternalId: "uid_22222222222222222222",
+            invoiceExternalId: "iid_33333333333333333333",
+            subtotal: "79.00",
+            discount: "4.00",
+            tax: "7.00",
+            shipping: "1.00",
+            total: "83.00",
+            items: [
+              {
+                productMongoId: "product-1",
+                productExternalId: "pid_44444444444444444444",
+                quantity: 1,
+                price: "39.00",
+                subtotal: "79.00",
+                tax: "7.00",
+              },
+            ],
+          },
+        ],
+      },
+      "order-expected"
+    );
+
+    expect(discrepancies).toEqual(
+      expect.arrayContaining([
+        "orderMongoId:order-expected->order-actual",
+        "buyerMongoId:buyer-1->buyer-2",
+        "total:100.00->101.00",
+        "totalAfterDiscount:90.00->92.00",
+        "discount:10.00->9.00",
+        "orderExternalId:oid_aaaaaaaaaaaaaaaaaaaa->oid_ffffffffffffffffffff",
+        "buyerExternalId:uid_bbbbbbbbbbbbbbbbbbbb->uid_11111111111111111111",
+        "vendor[0].vendorExternalId:uid_cccccccccccccccccccc->uid_22222222222222222222",
+        "vendor[0].invoiceExternalId:iid_dddddddddddddddddddd->iid_33333333333333333333",
+        "vendor[0].item[0].productExternalId:pid_eeeeeeeeeeeeeeeeeeee->pid_44444444444444444444",
+      ])
+    );
+  });
+
+  test("compareOrderDetailShadowParity keeps additive invoice-link behavior non-breaking", () => {
+    const discrepancies = compareOrderDetailShadowParity(
+      {
+        buyerMongoId: "buyer-1",
+        orderExternalId: null,
+        buyerExternalId: null,
+        total: "100.00",
+        totalAfterDiscount: "90.00",
+        discount: "10.00",
+        vendors: {
+          create: [
+            {
+              vendorMongoId: "vendor-1",
+              invoiceMongoId: null,
+              vendorExternalId: null,
+              invoiceExternalId: null,
+              subtotal: "80.00",
+              discount: "5.00",
+              tax: "8.00",
+              shipping: "2.00",
+              total: "85.00",
+              items: {
+                create: [
+                  {
+                    productMongoId: "product-1",
+                    productExternalId: null,
+                    quantity: 2,
+                    price: "40.00",
+                    subtotal: "80.00",
+                    tax: "8.00",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      {
+        mongoId: "order-1",
+        buyerMongoId: "buyer-1",
+        orderExternalId: "oid_aaaaaaaaaaaaaaaaaaaa",
+        buyerExternalId: "uid_bbbbbbbbbbbbbbbbbbbb",
+        total: "100.00",
+        totalAfterDiscount: "90.00",
+        discount: "10.00",
+        invoiceCount: 1,
+        vendors: [
+          {
+            vendorMongoId: "vendor-1",
+            invoiceMongoId: "invoice-1",
+            vendorExternalId: "uid_cccccccccccccccccccc",
+            invoiceExternalId: "iid_dddddddddddddddddddd",
+            subtotal: "80.00",
+            discount: "5.00",
+            tax: "8.00",
+            shipping: "2.00",
+            total: "85.00",
+            items: [
+              {
+                productMongoId: "product-1",
+                productExternalId: "pid_eeeeeeeeeeeeeeeeeeee",
+                quantity: 2,
+                price: "40.00",
+                subtotal: "80.00",
+                tax: "8.00",
+              },
+            ],
+          },
+        ],
+      },
+      "order-1"
+    );
+
+    expect(discrepancies).toEqual([]);
+  });
+
+  test("compareOrderDetailShadowParity enforces mirrored invoice-count invariant", () => {
+    const discrepancies = compareOrderDetailShadowParity(
+      {
+        buyerMongoId: "buyer-1",
+        orderExternalId: null,
+        buyerExternalId: null,
+        total: "100.00",
+        totalAfterDiscount: "100.00",
+        discount: "0.00",
+        vendors: {
+          create: [
+            {
+              vendorMongoId: "vendor-1",
+              invoiceMongoId: null,
+              subtotal: "100.00",
+              discount: "0.00",
+              tax: "0.00",
+              shipping: "0.00",
+              total: "100.00",
+              items: { create: [] },
+            },
+          ],
+        },
+      },
+      {
+        mongoId: "order-1",
+        buyerMongoId: "buyer-1",
+        orderExternalId: null,
+        buyerExternalId: null,
+        total: "100.00",
+        totalAfterDiscount: "100.00",
+        discount: "0.00",
+        invoiceCount: 0,
+        vendors: [
+          {
+            vendorMongoId: "vendor-1",
+            invoiceMongoId: "invoice-1",
+            subtotal: "100.00",
+            discount: "0.00",
+            tax: "0.00",
+            shipping: "0.00",
+            total: "100.00",
+            items: [],
+          },
+        ],
+      },
+      "order-1"
+    );
+
+    expect(discrepancies).toEqual(
+      expect.arrayContaining([
+        "invoiceCountInvariant:0->1",
+      ])
+    );
   });
 });

--- a/backend/tests/unit/services/orderPostgresMirror.test.js
+++ b/backend/tests/unit/services/orderPostgresMirror.test.js
@@ -567,9 +567,9 @@ describe("orderPostgresMirror", () => {
       expect.arrayContaining([
         "orderMongoId:order-expected->order-actual",
         "buyerMongoId:buyer-1->buyer-2",
-        "total:100.00->101.00",
-        "totalAfterDiscount:90.00->92.00",
-        "discount:10.00->9.00",
+          "total:100->101",
+          "totalAfterDiscount:90->92",
+          "discount:10->9",
         "orderExternalId:oid_aaaaaaaaaaaaaaaaaaaa->oid_ffffffffffffffffffff",
         "buyerExternalId:uid_bbbbbbbbbbbbbbbbbbbb->uid_11111111111111111111",
         "vendor[0].vendorExternalId:uid_cccccccccccccccccccc->uid_22222222222222222222",
@@ -709,5 +709,81 @@ describe("orderPostgresMirror", () => {
         "invoiceCountInvariant:0->1",
       ])
     );
+  });
+
+  test("compareOrderDetailShadowParity normalizes numeric formatting and ignores non-contract item monetary fields", () => {
+    const discrepancies = compareOrderDetailShadowParity(
+      {
+        buyerMongoId: "buyer-1",
+        orderExternalId: null,
+        buyerExternalId: null,
+        total: "240.00",
+        totalAfterDiscount: "240.00",
+        discount: "0.00",
+        vendors: {
+          create: [
+            {
+              vendorMongoId: "vendor-1",
+              invoiceMongoId: null,
+              vendorExternalId: null,
+              invoiceExternalId: null,
+              subtotal: "200.00",
+              discount: "0.00",
+              tax: "30.00",
+              shipping: "0.00",
+              total: "240.00",
+              items: {
+                create: [
+                  {
+                    productMongoId: "product-1",
+                    productExternalId: null,
+                    quantity: 2,
+                    price: "0.00",
+                    subtotal: "0.00",
+                    tax: "0.00",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      },
+      {
+        mongoId: "order-1",
+        buyerMongoId: "buyer-1",
+        orderExternalId: null,
+        buyerExternalId: null,
+        total: 240,
+        totalAfterDiscount: 240,
+        discount: 0,
+        invoiceCount: 1,
+        vendors: [
+          {
+            vendorMongoId: "vendor-1",
+            invoiceMongoId: "invoice-1",
+            vendorExternalId: null,
+            invoiceExternalId: null,
+            subtotal: 200,
+            discount: 0,
+            tax: 30,
+            shipping: 10,
+            total: 240,
+            items: [
+              {
+                productMongoId: "product-1",
+                productExternalId: null,
+                quantity: 2,
+                price: 100,
+                subtotal: 200,
+                tax: 30,
+              },
+            ],
+          },
+        ],
+      },
+      "order-1"
+    );
+
+    expect(discrepancies).toEqual([]);
   });
 });

--- a/docs/issues/tran-order-mirror-read-shadow-parity-proof-order-detail.md
+++ b/docs/issues/tran-order-mirror-read-shadow-parity-proof-order-detail.md
@@ -1,0 +1,49 @@
+Scope Lock — TRAN: Order mirror read-shadow parity proof (order detail contract)
+
+**Intent**
+Prove read-parity for the order detail contract using PostgreSQL mirror data in shadow mode only.
+This slice is proof-only and must not introduce read cutover, write cutover, or broad workflow changes.
+
+**NEW canonical path**
+
+* Treat mirrored canonical identity fields already propagated and completeness-hardened as the source keys for shadow read proof.
+* Define a narrow shadow projection contract for order detail parity checks only:
+
+  * order identity linkage
+  * buyer linkage
+  * vendor and item linkage
+  * order totals and invoice linkage invariants
+* Do not redefine canonical ID formats, generation rules, or model contracts in this slice.
+* Add focused parity assertions that validate mirror-derived order detail projection matches Mongo-authoritative order detail for the covered fields.
+
+**LEGACY path still present**
+
+* Existing Mongo-backed order read/write runtime remains authoritative.
+* Existing Mongo ObjectId-based live reads remain authoritative for all production responses.
+* No endpoint contract changes and no API payload semantic changes.
+* No request routing changes to serve order reads from PostgreSQL.
+
+**TRANSITIONAL bridge path, if any**
+
+* Add only shadow-read proof/check surfaces that construct a mirror-derived order detail projection and compare against Mongo source.
+* Keep all shadow behavior non-serving, additive, and non-breaking.
+* No read cutover.
+* No dual-write expansion beyond the existing mirror path.
+* No backfill jobs.
+* No migration orchestration.
+
+**Untouched surfaces**
+
+* No checkout, payment, shipment, returns, or analytics behavior changes.
+* No product catalog or vendor-account business logic changes.
+* No UI or E2E scope expansion beyond parity-proof checks required for this slice.
+* No schema-wide refactors.
+* No destination-read adoption in runtime request handling.
+
+**Hard boundaries**
+
+* Restrict changes to transitional mirror shadow-read projection, parity proof scripts/checks, and focused tests required for order detail parity evidence.
+* Preserve existing runtime behavior and public API contracts.
+* Do not introduce destination cutover logic.
+* MongoDB touches are allowed only where directly required to validate PostgreSQL shadow-read parity.
+* Keep PR in Draft until CI parity-proof evidence is complete and green.


### PR DESCRIPTION
Refs #83

**Title:**
Scope Lock — TRAN: Order mirror read-shadow parity proof (order detail contract)

**Why it should come next:**
You have completed foundation, propagation, and completeness proof on the write/mirror path. The next migration-risk checkpoint is read parity confidence without serving from PostgreSQL yet. This slice proves that the mirrored record can reproduce the existing order detail contract in shadow mode, so cutover decisions remain evidence-driven and low risk.

**Classification:**
TRAN

**Proposed branch name:**
tran-order-mirror-read-shadow-parity-proof-order-detail

**Exact scope-lock text:**

Scope Lock — TRAN: Order mirror read-shadow parity proof (order detail contract)

**Intent**
Prove read-parity for the order detail contract using PostgreSQL mirror data in shadow mode only.
This slice is proof-only and must not introduce read cutover, write cutover, or broad workflow changes.

**NEW canonical path**

* Treat mirrored canonical identity fields already propagated and completeness-hardened as the source keys for shadow read proof.
* Define a narrow shadow projection contract for order detail parity checks only:

  * order identity linkage
  * buyer linkage
  * vendor and item linkage
  * order totals and invoice linkage invariants
* Do not redefine canonical ID formats, generation rules, or model contracts in this slice.
* Add focused parity assertions that validate mirror-derived order detail projection matches Mongo-authoritative order detail for the covered fields.

**LEGACY path still present**

* Existing Mongo-backed order read/write runtime remains authoritative.
* Existing Mongo ObjectId-based live reads remain authoritative for all production responses.
* No endpoint contract changes and no API payload semantic changes.
* No request routing changes to serve order reads from PostgreSQL.

**TRANSITIONAL bridge path, if any**

* Add only shadow-read proof/check surfaces that construct a mirror-derived order detail projection and compare against Mongo source.
* Keep all shadow behavior non-serving, additive, and non-breaking.
* No read cutover.
* No dual-write expansion beyond the existing mirror path.
* No backfill jobs.
* No migration orchestration.

**Untouched surfaces**

* No checkout, payment, shipment, returns, or analytics behavior changes.
* No product catalog or vendor-account business logic changes.
* No UI or E2E scope expansion beyond parity-proof checks required for this slice.
* No schema-wide refactors.
* No destination-read adoption in runtime request handling.

**Hard boundaries**

* Restrict changes to transitional mirror shadow-read projection, parity proof scripts/checks, and focused tests required for order detail parity evidence.
* Preserve existing runtime behavior and public API contracts.
* Do not introduce destination cutover logic.
* MongoDB touches are allowed only where directly required to validate PostgreSQL shadow-read parity.
* Keep PR in Draft until CI parity-proof evidence is complete and green.
