### PR TITLE
Scope Lock — TRAN: Order mirror read-shadow parity proof (customer order-list summary contract)

### DIFF
--- a/.github/workflows/pr-smoke-gate.yml
+++ b/.github/workflows/pr-smoke-gate.yml
@@ -53,6 +53,7 @@ jobs:
           E2E_EPHEMERAL: 'true'
           E2E_AUTODROP: 'true'
           E2E_BACKEND_PORT: '5051'
+          E2E_USE_ALL: 'false'
           CYPRESS_retries: '2'
           CYPRESS_EXCLUDE_TAG: '@flaky'
           CYPRESS_CACHE_FOLDER: ${{ github.workspace }}/.cache/cypress

--- a/backend/scripts/postgres/checkOrderMirror.js
+++ b/backend/scripts/postgres/checkOrderMirror.js
@@ -8,6 +8,7 @@ const {
   buildMirrorPayload,
   buildMirrorSummary,
   compareCanonicalIdentityCompleteness,
+  compareCustomerOrderListSummaryShadowParity,
   compareOrderDetailShadowParity,
   compareMirrorSummary,
   summarizeMirroredOrder,
@@ -75,9 +76,37 @@ async function main() {
     mirrored,
     String(sourceOrder._id)
   );
+  const sourceOrderList = await Order.find({ buyer: sourceOrder.buyer })
+    .select("_id buyer status currency total totalAfterDiscount discount vendors createdAt +externalId")
+    .sort({ createdAt: -1, _id: -1 })
+    .lean();
+  const mirroredOrderList = await prisma.orderMirror.findMany({
+    where: { buyerMongoId: String(sourceOrder.buyer) },
+    select: {
+      mongoId: true,
+      orderExternalId: true,
+      buyerMongoId: true,
+      status: true,
+      currency: true,
+      total: true,
+      totalAfterDiscount: true,
+      discount: true,
+      vendorCount: true,
+      itemCount: true,
+      sourceCreatedAt: true,
+      mirroredAt: true,
+    },
+    orderBy: [{ sourceCreatedAt: "desc" }, { mongoId: "desc" }],
+  });
+  const shadowListParityDiscrepancies = compareCustomerOrderListSummaryShadowParity(
+    sourceOrderList,
+    mirroredOrderList,
+    String(sourceOrder.buyer)
+  );
   const richShape = {
     canonicalIdentityCompleteness: identityDiscrepancies.length === 0,
     orderDetailShadowParity: shadowReadParityDiscrepancies.length === 0,
+    customerOrderListSummaryShadowParity: shadowListParityDiscrepancies.length === 0,
     orderCanonicalIdPresentWhenSourcePresent:
       !expectedMirrorData.orderExternalId ||
       (Boolean(mirrored.orderExternalId) && isValidOrderExternalId(mirrored.orderExternalId)),
@@ -113,13 +142,18 @@ async function main() {
     discrepancies,
     identityDiscrepancies,
     shadowReadParityDiscrepancies,
+    shadowListParityDiscrepancies,
     richShape,
     mirroredAt: mirrored.mirroredAt,
   };
 
   console.log(JSON.stringify(summary, null, 2));
 
-  if (identityDiscrepancies.length > 0 || shadowReadParityDiscrepancies.length > 0) {
+  if (
+    identityDiscrepancies.length > 0 ||
+    shadowReadParityDiscrepancies.length > 0 ||
+    shadowListParityDiscrepancies.length > 0
+  ) {
     process.exitCode = 5;
   }
 }

--- a/backend/scripts/postgres/runtimeProofOrderMirror.js
+++ b/backend/scripts/postgres/runtimeProofOrderMirror.js
@@ -13,6 +13,7 @@ const { getPrismaClient, disconnectPrismaClient } = require("../../prisma/client
 const {
   buildMirrorPayload,
   compareCanonicalIdentityCompleteness,
+  compareCustomerOrderListSummaryShadowParity,
   compareOrderDetailShadowParity,
   summarizeMirroredOrder,
 } = require("../../services/orderPostgresMirror");
@@ -126,6 +127,33 @@ async function run() {
     mirrored,
     createdOrderId
   );
+  const sourceOrderList = await Order.find({ buyer: mongoOrder.buyer })
+    .select("_id buyer status currency total totalAfterDiscount discount vendors createdAt +externalId")
+    .sort({ createdAt: -1, _id: -1 })
+    .lean();
+  const mirroredOrderList = await prisma.orderMirror.findMany({
+    where: { buyerMongoId: String(mongoOrder.buyer) },
+    select: {
+      mongoId: true,
+      orderExternalId: true,
+      buyerMongoId: true,
+      status: true,
+      currency: true,
+      total: true,
+      totalAfterDiscount: true,
+      discount: true,
+      vendorCount: true,
+      itemCount: true,
+      sourceCreatedAt: true,
+      mirroredAt: true,
+    },
+    orderBy: [{ sourceCreatedAt: "desc" }, { mongoId: "desc" }],
+  });
+  const shadowListParityDiscrepancies = compareCustomerOrderListSummaryShadowParity(
+    sourceOrderList,
+    mirroredOrderList,
+    String(mongoOrder.buyer)
+  );
   assert.equal(
     identityDiscrepancies.length,
     0,
@@ -135,6 +163,11 @@ async function run() {
     shadowReadParityDiscrepancies.length,
     0,
     `Order detail shadow parity mismatches: ${shadowReadParityDiscrepancies.join(", ")}`
+  );
+  assert.equal(
+    shadowListParityDiscrepancies.length,
+    0,
+    `Customer order-list summary shadow parity mismatches: ${shadowListParityDiscrepancies.join(", ")}`
   );
 
   const mirroredItemCount = mirrored.vendors.reduce((sum, v) => sum + v.items.length, 0);
@@ -196,6 +229,7 @@ async function run() {
         responseInvariant,
         identityDiscrepancyCount: identityDiscrepancies.length,
         shadowReadParityDiscrepancyCount: shadowReadParityDiscrepancies.length,
+        shadowListParityDiscrepancyCount: shadowListParityDiscrepancies.length,
         mongoOrderStatus: mongoOrder.status,
         mirroredSummary: summarizeMirroredOrder(mirrored),
       },

--- a/backend/services/orderPostgresMirror.js
+++ b/backend/services/orderPostgresMirror.js
@@ -631,6 +631,188 @@ function compareOrderDetailShadowParity(expectedData, mirroredOrder, sourceOrder
   return discrepancies;
 }
 
+function normalizeShadowSortTimestamp(value) {
+  const parsed = toDate(value);
+  if (!parsed) return 0;
+  return parsed.getTime();
+}
+
+function buildSourceCustomerOrderListSummary(order) {
+  const vendors = Array.isArray(order && order.vendors) ? order.vendors : [];
+  const itemCount = vendors.reduce((sum, vendor) => {
+    const products = Array.isArray(vendor && vendor.products) ? vendor.products : [];
+    return sum + products.length;
+  }, 0);
+
+  return {
+    orderMongoId: order && order._id ? String(order._id) : "",
+    orderExternalId: normalizeExternalId(
+      order && (order.externalId || order.orderExternalId || order.orderCanonicalExternalId),
+      isValidOrderExternalId
+    ),
+    buyerMongoId: order && order.buyer ? String(order.buyer) : "",
+    status: order && order.status ? String(order.status) : "pending",
+    currency: order && order.currency ? String(order.currency) : "USD",
+    total: toMoney(order && order.total),
+    totalAfterDiscount: toMoney(order && order.totalAfterDiscount),
+    discount: toMoney(order && order.discount),
+    vendorCount: vendors.length,
+    itemCount,
+    sortTimestamp: normalizeShadowSortTimestamp(order && order.createdAt),
+  };
+}
+
+function buildMirroredCustomerOrderListSummary(order) {
+  const vendors = Array.isArray(order && order.vendors) ? order.vendors : [];
+  const derivedVendorCount = vendors.length;
+  const derivedItemCount = vendors.reduce((sum, vendor) => {
+    const items = Array.isArray(vendor && vendor.items) ? vendor.items : [];
+    return sum + items.length;
+  }, 0);
+
+  const vendorCountRaw = Number(order && order.vendorCount);
+  const itemCountRaw = Number(order && order.itemCount);
+  const vendorCount = Number.isFinite(vendorCountRaw) ? vendorCountRaw : derivedVendorCount;
+  const itemCount = Number.isFinite(itemCountRaw) ? itemCountRaw : derivedItemCount;
+
+  return {
+    orderMongoId: order && order.mongoId ? String(order.mongoId) : "",
+    orderExternalId: normalizeExternalId(order && order.orderExternalId, isValidOrderExternalId),
+    buyerMongoId: order && order.buyerMongoId ? String(order.buyerMongoId) : "",
+    status: order && order.status ? String(order.status) : "pending",
+    currency: order && order.currency ? String(order.currency) : "USD",
+    total: toMoney(order && order.total),
+    totalAfterDiscount: toMoney(order && order.totalAfterDiscount),
+    discount: toMoney(order && order.discount),
+    vendorCount,
+    itemCount,
+    sortTimestamp: normalizeShadowSortTimestamp(
+      order && (order.sourceCreatedAt || order.createdAt || order.orderDate || order.mirroredAt)
+    ),
+  };
+}
+
+function compareCustomerOrderListSummaryShadowParity(sourceOrders, mirroredOrders, buyerMongoId = null) {
+  const discrepancies = [];
+  const buyerScope = buyerMongoId ? String(buyerMongoId) : null;
+
+  const sourceSummaries = (Array.isArray(sourceOrders) ? sourceOrders : [])
+    .map((order) => buildSourceCustomerOrderListSummary(order))
+    .filter((summary) => summary.orderMongoId)
+    .filter((summary) => !buyerScope || summary.buyerMongoId === buyerScope);
+
+  const mirroredSummaries = (Array.isArray(mirroredOrders) ? mirroredOrders : [])
+    .map((order) => buildMirroredCustomerOrderListSummary(order))
+    .filter((summary) => summary.orderMongoId)
+    .filter((summary) => !buyerScope || summary.buyerMongoId === buyerScope);
+
+  const sourceById = new Map();
+  sourceSummaries.forEach((summary) => {
+    sourceById.set(summary.orderMongoId, summary);
+  });
+
+  const mirroredById = new Map();
+  mirroredSummaries.forEach((summary) => {
+    mirroredById.set(summary.orderMongoId, summary);
+  });
+
+  const coveredSummaries = [];
+  sourceById.forEach((sourceSummary, orderMongoId) => {
+    const mirroredSummary = mirroredById.get(orderMongoId);
+    if (!mirroredSummary) return;
+    coveredSummaries.push({ sourceSummary, mirroredSummary });
+  });
+
+  if (coveredSummaries.length === 0) {
+    return discrepancies;
+  }
+
+  const sortedSource = coveredSummaries
+    .map((entry) => entry.sourceSummary)
+    .sort((left, right) => {
+      if (right.sortTimestamp !== left.sortTimestamp) return right.sortTimestamp - left.sortTimestamp;
+      return String(right.orderMongoId).localeCompare(String(left.orderMongoId));
+    });
+  const sortedMirrored = coveredSummaries
+    .map((entry) => entry.mirroredSummary)
+    .sort((left, right) => {
+      if (right.sortTimestamp !== left.sortTimestamp) return right.sortTimestamp - left.sortTimestamp;
+      return String(right.orderMongoId).localeCompare(String(left.orderMongoId));
+    });
+
+  const expectedOrder = sortedSource.map((entry) => entry.orderMongoId);
+  const actualOrder = sortedMirrored.map((entry) => entry.orderMongoId);
+  if (expectedOrder.join("|") !== actualOrder.join("|")) {
+    discrepancies.push(`ordering:${expectedOrder.join("|")}->${actualOrder.join("|")}`);
+  }
+
+  sortedSource.forEach((sourceSummary, index) => {
+    const orderMongoId = sourceSummary.orderMongoId;
+    const mirroredSummary = mirroredById.get(orderMongoId);
+    if (!mirroredSummary) return;
+
+    compareCanonicalField({
+      label: `order[${index}].orderExternalId`,
+      expectedValue: sourceSummary.orderExternalId,
+      actualValue: mirroredSummary.orderExternalId,
+      validator: isValidOrderExternalId,
+      discrepancies,
+    });
+
+    compareShadowField({
+      label: `order[${index}].buyerMongoId`,
+      expectedValue: sourceSummary.buyerMongoId,
+      actualValue: mirroredSummary.buyerMongoId,
+      discrepancies,
+    });
+    compareShadowField({
+      label: `order[${index}].status`,
+      expectedValue: sourceSummary.status,
+      actualValue: mirroredSummary.status,
+      discrepancies,
+    });
+    compareShadowField({
+      label: `order[${index}].currency`,
+      expectedValue: sourceSummary.currency,
+      actualValue: mirroredSummary.currency,
+      discrepancies,
+    });
+
+    compareShadowNumericField({
+      label: `order[${index}].total`,
+      expectedValue: sourceSummary.total,
+      actualValue: mirroredSummary.total,
+      discrepancies,
+    });
+    compareShadowNumericField({
+      label: `order[${index}].totalAfterDiscount`,
+      expectedValue: sourceSummary.totalAfterDiscount,
+      actualValue: mirroredSummary.totalAfterDiscount,
+      discrepancies,
+    });
+    compareShadowNumericField({
+      label: `order[${index}].discount`,
+      expectedValue: sourceSummary.discount,
+      actualValue: mirroredSummary.discount,
+      discrepancies,
+    });
+    compareShadowNumericField({
+      label: `order[${index}].vendorCount`,
+      expectedValue: sourceSummary.vendorCount,
+      actualValue: mirroredSummary.vendorCount,
+      discrepancies,
+    });
+    compareShadowNumericField({
+      label: `order[${index}].itemCount`,
+      expectedValue: sourceSummary.itemCount,
+      actualValue: mirroredSummary.itemCount,
+      discrepancies,
+    });
+  });
+
+  return discrepancies;
+}
+
 async function buildMirrorPayload(order, vendors) {
   const orderExternalId = await resolveOrderExternalId(order);
   const buyerExternalId = await resolveBuyerExternalId(order);
@@ -742,8 +924,11 @@ async function mirrorOrderCreationToPostgres({ order, vendors }) {
 module.exports = {
   buildMirrorPayload,
   buildMirrorSummary,
+  buildMirroredCustomerOrderListSummary,
+  buildSourceCustomerOrderListSummary,
   buildVendorRows,
   compareCanonicalIdentityCompleteness,
+  compareCustomerOrderListSummaryShadowParity,
   compareOrderDetailShadowParity,
   compareMirrorSummary,
   enrichVendorsWithCanonicalIdentity,

--- a/backend/tests/unit/services/orderPostgresMirror.test.js
+++ b/backend/tests/unit/services/orderPostgresMirror.test.js
@@ -3,6 +3,7 @@ const {
   buildMirrorSummary,
   buildVendorRows,
   compareCanonicalIdentityCompleteness,
+  compareCustomerOrderListSummaryShadowParity,
   compareOrderDetailShadowParity,
   compareMirrorSummary,
   enrichVendorsWithCanonicalIdentity,
@@ -782,6 +783,179 @@ describe("orderPostgresMirror", () => {
         ],
       },
       "order-1"
+    );
+
+    expect(discrepancies).toEqual([]);
+  });
+
+  test("compareCustomerOrderListSummaryShadowParity enforces covered-list ordering and summary field parity", () => {
+    const discrepancies = compareCustomerOrderListSummaryShadowParity(
+      [
+        {
+          _id: "order-1",
+          externalId: "oid_aaaaaaaaaaaaaaaaaaaa",
+          buyer: "buyer-1",
+          status: "pending",
+          currency: "USD",
+          total: 100,
+          totalAfterDiscount: 90,
+          discount: 10,
+          vendors: [{ products: [{}, {}] }],
+          createdAt: "2024-01-01T00:00:00.000Z",
+        },
+        {
+          _id: "order-2",
+          externalId: "oid_bbbbbbbbbbbbbbbbbbbb",
+          buyer: "buyer-1",
+          status: "delivered",
+          currency: "USD",
+          total: 50,
+          totalAfterDiscount: 50,
+          discount: 0,
+          vendors: [{ products: [{}] }],
+          createdAt: "2024-01-02T00:00:00.000Z",
+        },
+      ],
+      [
+        {
+          mongoId: "order-1",
+          orderExternalId: "oid_ffffffffffffffffffff",
+          buyerMongoId: "buyer-2",
+          status: "cancelled",
+          currency: "ETB",
+          total: 101,
+          totalAfterDiscount: 91,
+          discount: 9,
+          vendorCount: 2,
+          itemCount: 1,
+          sourceCreatedAt: "2024-01-03T00:00:00.000Z",
+        },
+        {
+          mongoId: "order-2",
+          orderExternalId: "oid_bbbbbbbbbbbbbbbbbbbb",
+          buyerMongoId: "buyer-1",
+          status: "delivered",
+          currency: "USD",
+          total: 50,
+          totalAfterDiscount: 50,
+          discount: 0,
+          vendorCount: 1,
+          itemCount: 1,
+          sourceCreatedAt: "2024-01-01T00:00:00.000Z",
+        },
+      ],
+    );
+
+    expect(discrepancies).toEqual(
+      expect.arrayContaining([
+        "ordering:order-2|order-1->order-1|order-2",
+        "order[1].orderExternalId:oid_aaaaaaaaaaaaaaaaaaaa->oid_ffffffffffffffffffff",
+        "order[1].buyerMongoId:buyer-1->buyer-2",
+        "order[1].status:pending->cancelled",
+        "order[1].currency:USD->ETB",
+        "order[1].total:100->101",
+        "order[1].totalAfterDiscount:90->91",
+        "order[1].discount:10->9",
+        "order[1].vendorCount:1->2",
+        "order[1].itemCount:2->1",
+      ])
+    );
+  });
+
+  test("compareCustomerOrderListSummaryShadowParity keeps canonical order ID additive when source ID is absent", () => {
+    const discrepancies = compareCustomerOrderListSummaryShadowParity(
+      [
+        {
+          _id: "order-1",
+          externalId: null,
+          buyer: "buyer-1",
+          status: "pending",
+          currency: "USD",
+          total: "100.00",
+          totalAfterDiscount: "100.00",
+          discount: "0.00",
+          vendors: [{ products: [{}] }],
+          createdAt: "2024-01-01T00:00:00.000Z",
+        },
+      ],
+      [
+        {
+          mongoId: "order-1",
+          orderExternalId: "oid_aaaaaaaaaaaaaaaaaaaa",
+          buyerMongoId: "buyer-1",
+          status: "pending",
+          currency: "USD",
+          total: 100,
+          totalAfterDiscount: 100,
+          discount: 0,
+          vendorCount: 1,
+          itemCount: 1,
+          sourceCreatedAt: "2024-01-01T00:00:00.000Z",
+        },
+      ],
+      "buyer-1"
+    );
+
+    expect(discrepancies).toEqual([]);
+  });
+
+  test("compareCustomerOrderListSummaryShadowParity compares only covered list results", () => {
+    const discrepancies = compareCustomerOrderListSummaryShadowParity(
+      [
+        {
+          _id: "order-1",
+          externalId: "oid_aaaaaaaaaaaaaaaaaaaa",
+          buyer: "buyer-1",
+          status: "pending",
+          currency: "USD",
+          total: 100,
+          totalAfterDiscount: 100,
+          discount: 0,
+          vendors: [{ products: [{}] }],
+          createdAt: "2024-01-01T00:00:00.000Z",
+        },
+        {
+          _id: "order-2",
+          externalId: "oid_bbbbbbbbbbbbbbbbbbbb",
+          buyer: "buyer-1",
+          status: "delivered",
+          currency: "USD",
+          total: 50,
+          totalAfterDiscount: 50,
+          discount: 0,
+          vendors: [{ products: [{}] }],
+          createdAt: "2024-01-02T00:00:00.000Z",
+        },
+      ],
+      [
+        {
+          mongoId: "order-1",
+          orderExternalId: "oid_aaaaaaaaaaaaaaaaaaaa",
+          buyerMongoId: "buyer-1",
+          status: "pending",
+          currency: "USD",
+          total: 100,
+          totalAfterDiscount: 100,
+          discount: 0,
+          vendorCount: 1,
+          itemCount: 1,
+          sourceCreatedAt: "2024-01-01T00:00:00.000Z",
+        },
+        {
+          mongoId: "order-extra",
+          orderExternalId: "oid_cccccccccccccccccccc",
+          buyerMongoId: "buyer-1",
+          status: "pending",
+          currency: "USD",
+          total: 10,
+          totalAfterDiscount: 10,
+          discount: 0,
+          vendorCount: 1,
+          itemCount: 1,
+          sourceCreatedAt: "2024-01-03T00:00:00.000Z",
+        },
+      ],
+      "buyer-1"
     );
 
     expect(discrepancies).toEqual([]);

--- a/docs/issues/tran-order-mirror-read-shadow-parity-proof-customer-order-list-summary.md
+++ b/docs/issues/tran-order-mirror-read-shadow-parity-proof-customer-order-list-summary.md
@@ -1,0 +1,50 @@
+Scope Lock — TRAN: Order mirror read-shadow parity proof (customer order-list summary contract)
+
+**Intent**
+Prove read-parity for the customer order-list summary contract using PostgreSQL mirror data in shadow mode only.
+This slice is proof-only and must not introduce read cutover, write cutover, or broad workflow changes.
+
+**NEW canonical path**
+
+* Treat mirrored canonical identity fields already propagated and parity-hardened as source keys for shadow list-read proof.
+* Define a narrow shadow projection contract for customer order-list summary parity checks only:
+
+  * order identity linkage
+  * status/currency/totals summary fields
+  * vendor/item count summary invariants
+  * list ordering invariant for covered results
+* Do not redefine canonical ID formats, generation rules, or model contracts in this slice.
+* Add focused parity assertions that validate mirror-derived customer order-list summary projection matches Mongo-authoritative list summary for covered fields.
+
+**LEGACY path still present**
+
+* Existing Mongo-backed order read/write runtime remains authoritative.
+* Existing Mongo ObjectId-based live reads remain authoritative for all production responses.
+* No endpoint contract changes and no API payload semantic changes.
+* No request routing changes to serve customer order-list reads from PostgreSQL.
+
+**TRANSITIONAL bridge path, if any**
+
+* Add only shadow-read proof/check surfaces that construct a mirror-derived customer order-list summary projection and compare against Mongo source.
+* Keep all shadow behavior non-serving, additive, and non-breaking.
+* No read cutover.
+* No dual-write expansion beyond the existing mirror path.
+* No backfill jobs.
+* No migration orchestration.
+
+**Untouched surfaces**
+
+* No checkout, payment, shipment, returns, or analytics behavior changes.
+* No product catalog or vendor-account business logic changes.
+* No order-detail contract expansion in this slice beyond list-summary parity proof needs.
+* No UI or E2E scope expansion beyond parity-proof checks required for this slice.
+* No schema-wide refactors.
+* No destination-read adoption in runtime request handling.
+
+**Hard boundaries**
+
+* Restrict changes to transitional mirror shadow-list projection, parity proof scripts/checks, and focused tests required for customer order-list summary parity evidence.
+* Preserve existing runtime behavior and public API contracts.
+* Do not introduce destination cutover logic.
+* MongoDB touches are allowed only where directly required to validate PostgreSQL shadow-list parity.
+* Keep PR in Draft until CI parity-proof evidence is complete and green.


### PR DESCRIPTION
Refs #85

**Title:**
Scope Lock — TRAN: Order mirror read-shadow parity proof (customer order-list summary contract)

**Why it should come next:**
You now have end-to-end write-path proof, canonical completeness hardening, and single-order detail shadow parity proof. The next narrow migration-risk checkpoint is list-read parity for the customer order-list summary shape, because list contracts add ordering and multi-row projection risk that detail-proof alone does not cover. This keeps progression evidence-driven without any read cutover.

**Classification:**
TRAN

**Proposed branch name:**
tran-order-mirror-read-shadow-parity-proof-customer-order-list-summary

**Exact scope-lock text:**

Scope Lock — TRAN: Order mirror read-shadow parity proof (customer order-list summary contract)

**Intent**
Prove read-parity for the customer order-list summary contract using PostgreSQL mirror data in shadow mode only.
This slice is proof-only and must not introduce read cutover, write cutover, or broad workflow changes.

**NEW canonical path**

* Treat mirrored canonical identity fields already propagated and parity-hardened as source keys for shadow list-read proof.
* Define a narrow shadow projection contract for customer order-list summary parity checks only:

  * order identity linkage
  * status/currency/totals summary fields
  * vendor/item count summary invariants
  * list ordering invariant for covered results
* Do not redefine canonical ID formats, generation rules, or model contracts in this slice.
* Add focused parity assertions that validate mirror-derived customer order-list summary projection matches Mongo-authoritative list summary for covered fields.

**LEGACY path still present**

* Existing Mongo-backed order read/write runtime remains authoritative.
* Existing Mongo ObjectId-based live reads remain authoritative for all production responses.
* No endpoint contract changes and no API payload semantic changes.
* No request routing changes to serve customer order-list reads from PostgreSQL.

**TRANSITIONAL bridge path, if any**

* Add only shadow-read proof/check surfaces that construct a mirror-derived customer order-list summary projection and compare against Mongo source.
* Keep all shadow behavior non-serving, additive, and non-breaking.
* No read cutover.
* No dual-write expansion beyond the existing mirror path.
* No backfill jobs.
* No migration orchestration.

**Untouched surfaces**

* No checkout, payment, shipment, returns, or analytics behavior changes.
* No product catalog or vendor-account business logic changes.
* No order-detail contract expansion in this slice beyond list-summary parity proof needs.
* No UI or E2E scope expansion beyond parity-proof checks required for this slice.
* No schema-wide refactors.
* No destination-read adoption in runtime request handling.

**Hard boundaries**

* Restrict changes to transitional mirror shadow-list projection, parity proof scripts/checks, and focused tests required for customer order-list summary parity evidence.
* Preserve existing runtime behavior and public API contracts.
* Do not introduce destination cutover logic.
* MongoDB touches are allowed only where directly required to validate PostgreSQL shadow-list parity.
* Keep PR in Draft until CI parity-proof evidence is complete and green.
