### PR TITLE
TRAN: Admin order-list serving-experiment readiness controls

### DIFF
--- a/backend/routes/adminOrders.js
+++ b/backend/routes/adminOrders.js
@@ -5,6 +5,7 @@ const ReturnRequest = require('../models/ReturnRequest');
 const { protect, authorize } = require('../middleware/authMiddleware');
 const { getPrismaClient } = require('../prisma/client');
 const {
+  evaluateAdminOrderListServingExperimentReadiness,
   evaluateAdminOrderListRuntimeShadowVerification,
   resolveOrdersPgMirrorMode,
 } = require('../services/orderPostgresMirror');
@@ -133,8 +134,12 @@ router.get('/', protect, authorize('admin', 'global_admin'), async (req, res) =>
         query: req.query,
       });
 
+      const readiness = evaluateAdminOrderListServingExperimentReadiness({
+        runtimeParity,
+      });
+
       if (runtimeParity) {
-        const telemetry = {
+        const parityTelemetry = {
           event: 'admin-order-list-runtime-read-shadow-verification',
           match: runtimeParity.match,
           mismatchClass: runtimeParity.mismatchClass,
@@ -148,15 +153,52 @@ router.get('/', protect, authorize('admin', 'global_admin'), async (req, res) =>
           latencyMs: runtimeParity.runtimeLatencyMs,
         };
 
-        if (!runtimeParity.match) {
-          console.warn(`[orders-postgres-mirror] ${JSON.stringify(telemetry)}`);
+        const readinessTelemetry = {
+          event: 'admin-order-list-serving-experiment-readiness-controls',
+          eligible: readiness.eligible,
+          blocked: readiness.blocked,
+          blockedReasons: readiness.blockedReasons,
+          failClosedDefaultLegacy: readiness.failClosedDefaultLegacy,
+          servingPathDecision: readiness.servingPathDecision,
+          controls: readiness.controls,
+          signals: readiness.signals,
+          evaluationInputs: readiness.evaluationInputs,
+        };
+
+        const gateOnlyBlock =
+          readiness.blocked &&
+          Array.isArray(readiness.blockedReasons) &&
+          readiness.blockedReasons.length === 1 &&
+          readiness.blockedReasons[0] === 'gate-disabled';
+
+        if (!runtimeParity.match || !gateOnlyBlock) {
+          console.warn(`[orders-postgres-mirror] ${JSON.stringify(parityTelemetry)}`);
+          console.warn(`[orders-postgres-mirror] ${JSON.stringify(readinessTelemetry)}`);
         } else if (String(process.env.ORDERS_PG_MIRROR_LOG_SUCCESS || '').toLowerCase() === 'true') {
-          console.log(`[orders-postgres-mirror] ${JSON.stringify(telemetry)}`);
+          console.log(`[orders-postgres-mirror] ${JSON.stringify(parityTelemetry)}`);
+          console.log(`[orders-postgres-mirror] ${JSON.stringify(readinessTelemetry)}`);
         }
       }
     } catch (shadowError) {
       const message = shadowError && shadowError.message ? shadowError.message : String(shadowError);
+      const readiness = evaluateAdminOrderListServingExperimentReadiness({
+        runtimeParity: null,
+        comparatorError: message,
+      });
       console.warn(`[orders-postgres-mirror] admin-order-list runtime read-shadow verification skipped: ${message}`);
+      console.warn(
+        `[orders-postgres-mirror] ${JSON.stringify({
+          event: 'admin-order-list-serving-experiment-readiness-controls',
+          eligible: readiness.eligible,
+          blocked: readiness.blocked,
+          blockedReasons: readiness.blockedReasons,
+          failClosedDefaultLegacy: readiness.failClosedDefaultLegacy,
+          servingPathDecision: readiness.servingPathDecision,
+          controls: readiness.controls,
+          signals: readiness.signals,
+          evaluationInputs: readiness.evaluationInputs,
+        })}`
+      );
     }
 
     // Return array directly to align with tests expecting an array response

--- a/backend/services/orderPostgresMirror.js
+++ b/backend/services/orderPostgresMirror.js
@@ -12,6 +12,46 @@ const {
 } = require("../utils/externalId");
 
 const VALID_MIRROR_MODES = new Set(["off", "best_effort"]);
+const VALID_ADMIN_ORDER_LIST_EXPERIMENT_GATES = new Set(["off", "ready"]);
+
+function parsePositiveInteger(rawValue, fallbackValue) {
+  const numeric = Number(rawValue);
+  if (!Number.isFinite(numeric) || numeric <= 0) return fallbackValue;
+  return Math.floor(numeric);
+}
+
+function resolveAdminOrderListServingExperimentControls() {
+  const gateRaw = String(process.env.ADMIN_ORDER_LIST_PG_SERVING_EXPERIMENT_GATE || "").trim().toLowerCase();
+  let gate = gateRaw || "off";
+  if (!VALID_ADMIN_ORDER_LIST_EXPERIMENT_GATES.has(gate)) {
+    if (gateRaw) {
+      console.warn(
+        `[orders-postgres-mirror] Invalid ADMIN_ORDER_LIST_PG_SERVING_EXPERIMENT_GATE=\"${gateRaw}\". Falling back to off.`
+      );
+    }
+    gate = "off";
+  }
+
+  const killSwitchRaw = String(process.env.ADMIN_ORDER_LIST_PG_SERVING_EXPERIMENT_KILL_SWITCH || "").trim().toLowerCase();
+  const killSwitchActive = killSwitchRaw === "true";
+
+  return {
+    gate,
+    gateEnabled: gate === "ready",
+    killSwitchActive,
+    failClosedDefaultLegacy: true,
+    latencyGuards: {
+      maxSourceMirrorDeltaMs: parsePositiveInteger(
+        process.env.ADMIN_ORDER_LIST_PG_READINESS_MAX_SOURCE_MIRROR_DELTA_MS,
+        2500
+      ),
+      maxComparatorMs: parsePositiveInteger(
+        process.env.ADMIN_ORDER_LIST_PG_READINESS_MAX_COMPARATOR_MS,
+        1500
+      ),
+    },
+  };
+}
 
 function resolveOrdersPgMirrorMode() {
   const rawMode = String(process.env.ORDERS_PG_MIRROR_MODE || "").trim().toLowerCase();
@@ -1021,6 +1061,94 @@ function evaluateAdminOrderListRuntimeShadowVerification(sourceOrders, mirroredO
   };
 }
 
+function evaluateAdminOrderListServingExperimentReadiness({ runtimeParity, comparatorError } = {}) {
+  const controls = resolveAdminOrderListServingExperimentControls();
+  const hasRuntimeParity = Boolean(runtimeParity && typeof runtimeParity === "object");
+  const runtimeLatency = hasRuntimeParity && runtimeParity.runtimeLatencyMs ? runtimeParity.runtimeLatencyMs : null;
+
+  const sourceMirrorDeltaMs = Number(runtimeLatency && runtimeLatency.sourceMirrorDelta);
+  const comparatorMs = Number(runtimeLatency && runtimeLatency.comparator);
+  const sourceMirrorDeltaExceeded =
+    Number.isFinite(sourceMirrorDeltaMs) && sourceMirrorDeltaMs > controls.latencyGuards.maxSourceMirrorDeltaMs;
+  const comparatorExceeded = Number.isFinite(comparatorMs) && comparatorMs > controls.latencyGuards.maxComparatorMs;
+
+  const comparatorHealthy =
+    hasRuntimeParity &&
+    Array.isArray(runtimeParity.discrepancies) &&
+    runtimeParity.coverage &&
+    Number.isFinite(Number(runtimeParity.coverage.coveredCount));
+
+  const telemetryHealthy =
+    hasRuntimeParity &&
+    runtimeParity.queryContract &&
+    runtimeParity.coverage &&
+    Number.isFinite(Number(runtimeParity.coverage.sourceCount)) &&
+    Number.isFinite(Number(runtimeParity.coverage.mirroredCount)) &&
+    Number.isFinite(Number(runtimeParity.coverage.coveredCount)) &&
+    runtimeLatency &&
+    Number.isFinite(Number(runtimeLatency.sourceQuery)) &&
+    Number.isFinite(Number(runtimeLatency.mirrorQuery)) &&
+    Number.isFinite(Number(runtimeLatency.comparator)) &&
+    Number.isFinite(Number(runtimeLatency.sourceMirrorDelta));
+
+  const mismatchClassSignal = hasRuntimeParity
+    ? runtimeParity.mismatchClass || "none"
+    : comparatorError
+      ? "comparator-error"
+      : "missing-runtime-parity";
+
+  const blockedReasons = [];
+  if (!controls.gateEnabled) blockedReasons.push("gate-disabled");
+  if (controls.killSwitchActive) blockedReasons.push("kill-switch-active");
+  if (comparatorError) blockedReasons.push("comparator-error");
+  if (!telemetryHealthy) blockedReasons.push("telemetry-health-degraded");
+  if (!comparatorHealthy) blockedReasons.push("comparator-health-degraded");
+
+  const coverage = hasRuntimeParity && runtimeParity.coverage ? runtimeParity.coverage : null;
+  if (coverage && Number(coverage.coveredCount) <= 0) blockedReasons.push("coverage-gap");
+
+  if (hasRuntimeParity && runtimeParity.mismatchClass) {
+    blockedReasons.push(`mismatch-class-${runtimeParity.mismatchClass}`);
+  }
+  if (sourceMirrorDeltaExceeded) blockedReasons.push("latency-guard-source-mirror-delta-exceeded");
+  if (comparatorExceeded) blockedReasons.push("latency-guard-comparator-exceeded");
+  if (!hasRuntimeParity) blockedReasons.push("no-runtime-parity-signal");
+
+  const blocked = blockedReasons.length > 0;
+  const eligible = !blocked;
+
+  return {
+    eligible,
+    blocked,
+    blockedReasons,
+    failClosedDefaultLegacy: true,
+    controls,
+    evaluationInputs: {
+      gate: controls.gate,
+      killSwitchActive: controls.killSwitchActive,
+      mismatchClassSignal,
+      comparatorConfidence: hasRuntimeParity ? runtimeParity.comparatorConfidence || null : null,
+      discrepancyCount: hasRuntimeParity && Array.isArray(runtimeParity.discrepancies)
+        ? runtimeParity.discrepancies.length
+        : null,
+      coverage,
+      latencyMs: runtimeLatency,
+    },
+    signals: {
+      mismatchClass: mismatchClassSignal,
+      telemetryHealth: telemetryHealthy ? "healthy" : "degraded",
+      comparatorHealth: comparatorHealthy ? "healthy" : "degraded",
+      latencyGuard: {
+        sourceMirrorDeltaMs: Number.isFinite(sourceMirrorDeltaMs) ? sourceMirrorDeltaMs : null,
+        comparatorMs: Number.isFinite(comparatorMs) ? comparatorMs : null,
+        sourceMirrorDeltaExceeded,
+        comparatorExceeded,
+      },
+    },
+    servingPathDecision: blocked ? "blocked-legacy-only" : "eligible-for-future-experiment",
+  };
+}
+
 function compareAdminOrderListSummaryShadowParity(sourceOrders, mirroredOrders) {
   const discrepancies = [];
 
@@ -1603,6 +1731,7 @@ module.exports = {
   compareCanonicalIdentityCompleteness,
   compareCustomerOrderListSummaryShadowParity,
   compareOrderDetailShadowParity,
+  evaluateAdminOrderListServingExperimentReadiness,
   evaluateAdminOrderListRuntimeShadowVerification,
   compareMirrorSummary,
   compareVendorOrderListSummaryShadowParity,
@@ -1610,6 +1739,7 @@ module.exports = {
   mirrorOrderCreationToPostgres,
   resolveBuyerExternalId,
   resolveOrderExternalId,
+  resolveAdminOrderListServingExperimentControls,
   resolveOrdersPgMirrorMode,
   summarizeMirroredOrder,
 };

--- a/backend/tests/unit/routes/adminOrders.readinessControls.test.js
+++ b/backend/tests/unit/routes/adminOrders.readinessControls.test.js
@@ -1,0 +1,139 @@
+const express = require("express");
+const request = require("supertest");
+
+const mongoOrders = [
+  { _id: "mongo-order-1", total: 42.5, status: "pending" },
+];
+
+function buildFindChain(rows) {
+  return {
+    limit: jest.fn().mockReturnValue({
+      lean: jest.fn().mockResolvedValue(rows),
+    }),
+  };
+}
+
+jest.mock("../../../models/Order", () => ({
+  find: jest.fn(),
+  create: jest.fn(),
+  findById: jest.fn(),
+}));
+
+jest.mock("../../../models/ReturnRequest", () => ({}));
+
+jest.mock("../../../middleware/authMiddleware", () => ({
+  protect: (req, _res, next) => {
+    req.user = { _id: "admin-user", roles: ["admin"] };
+    next();
+  },
+  authorize: () => (_req, _res, next) => next(),
+}));
+
+jest.mock("../../../prisma/client", () => ({
+  getPrismaClient: jest.fn(),
+}));
+
+jest.mock("../../../services/orderPostgresMirror", () => ({
+  resolveOrdersPgMirrorMode: jest.fn(),
+  evaluateAdminOrderListRuntimeShadowVerification: jest.fn(),
+  evaluateAdminOrderListServingExperimentReadiness: jest.fn(),
+}));
+
+const Order = require("../../../models/Order");
+const { getPrismaClient } = require("../../../prisma/client");
+const {
+  resolveOrdersPgMirrorMode,
+  evaluateAdminOrderListRuntimeShadowVerification,
+  evaluateAdminOrderListServingExperimentReadiness,
+} = require("../../../services/orderPostgresMirror");
+const adminOrdersRouter = require("../../../routes/adminOrders");
+
+describe("adminOrders route readiness controls (telemetry-only)", () => {
+  let app;
+  let consoleWarnSpy;
+  let consoleLogSpy;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    app = express();
+    app.use(express.json());
+    app.use("/api/admin/orders", adminOrdersRouter);
+
+    consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    Order.find.mockReturnValue(buildFindChain(mongoOrders));
+    getPrismaClient.mockReturnValue({
+      orderMirror: {
+        findMany: jest.fn().mockResolvedValue([
+          { mongoId: "mirror-order-1", status: "cancelled" },
+        ]),
+      },
+    });
+  });
+
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+  });
+
+  test("keeps readiness logic telemetry-only and serves Mongo orders", async () => {
+    resolveOrdersPgMirrorMode.mockReturnValue("best_effort");
+    evaluateAdminOrderListRuntimeShadowVerification.mockReturnValue({
+      match: false,
+      mismatchClass: "query-semantics",
+      comparatorConfidence: "low",
+      discrepancies: ["runtime.query.sort:mismatch"],
+      coverage: { sourceCount: 1, mirroredCount: 1, coveredCount: 1 },
+      queryContract: { status: "pending", page: 1, limit: 20 },
+    });
+    evaluateAdminOrderListServingExperimentReadiness.mockReturnValue({
+      eligible: false,
+      blocked: true,
+      blockedReasons: ["mismatch-class-query-semantics"],
+      failClosedDefaultLegacy: true,
+      servingPathDecision: "blocked-legacy-only",
+      controls: { gate: "ready", gateEnabled: true, killSwitchActive: false },
+      signals: { telemetryHealth: "healthy", comparatorHealth: "healthy" },
+      evaluationInputs: { mismatchClassSignal: "query-semantics" },
+    });
+
+    const res = await request(app).get("/api/admin/orders");
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(mongoOrders);
+    expect(evaluateAdminOrderListRuntimeShadowVerification).toHaveBeenCalledTimes(1);
+    expect(evaluateAdminOrderListServingExperimentReadiness).toHaveBeenCalledWith(
+      expect.objectContaining({ runtimeParity: expect.any(Object) })
+    );
+  });
+
+  test("comparator or readiness failure cannot switch serving path", async () => {
+    resolveOrdersPgMirrorMode.mockReturnValue("best_effort");
+    evaluateAdminOrderListRuntimeShadowVerification.mockImplementation(() => {
+      throw new Error("forced-comparator-failure");
+    });
+    evaluateAdminOrderListServingExperimentReadiness.mockReturnValue({
+      eligible: false,
+      blocked: true,
+      blockedReasons: ["comparator-error", "no-runtime-parity-signal"],
+      failClosedDefaultLegacy: true,
+      servingPathDecision: "blocked-legacy-only",
+      controls: { gate: "ready", gateEnabled: true, killSwitchActive: false },
+      signals: { telemetryHealth: "degraded", comparatorHealth: "degraded" },
+      evaluationInputs: { mismatchClassSignal: "comparator-error" },
+    });
+
+    const res = await request(app).get("/api/admin/orders");
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual(mongoOrders);
+    expect(evaluateAdminOrderListServingExperimentReadiness).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeParity: null,
+        comparatorError: "forced-comparator-failure",
+      })
+    );
+  });
+});

--- a/backend/tests/unit/services/orderPostgresMirror.test.js
+++ b/backend/tests/unit/services/orderPostgresMirror.test.js
@@ -7,10 +7,12 @@ const {
   compareCanonicalIdentityCompleteness,
   compareCustomerOrderListSummaryShadowParity,
   compareOrderDetailShadowParity,
+  evaluateAdminOrderListServingExperimentReadiness,
   evaluateAdminOrderListRuntimeShadowVerification,
   compareMirrorSummary,
   compareVendorOrderListSummaryShadowParity,
   enrichVendorsWithCanonicalIdentity,
+  resolveAdminOrderListServingExperimentControls,
   resolveBuyerExternalId,
   resolveOrderExternalId,
   resolveOrdersPgMirrorMode,
@@ -33,6 +35,31 @@ describe("orderPostgresMirror", () => {
     process.env.ORDERS_PG_MIRROR_MODE = "unsupported";
 
     expect(resolveOrdersPgMirrorMode()).toBe("off");
+  });
+
+  test("resolveAdminOrderListServingExperimentControls defaults to fail-closed legacy behavior", () => {
+    delete process.env.ADMIN_ORDER_LIST_PG_SERVING_EXPERIMENT_GATE;
+    delete process.env.ADMIN_ORDER_LIST_PG_SERVING_EXPERIMENT_KILL_SWITCH;
+
+    const controls = resolveAdminOrderListServingExperimentControls();
+
+    expect(controls).toMatchObject({
+      gate: "off",
+      gateEnabled: false,
+      killSwitchActive: false,
+      failClosedDefaultLegacy: true,
+    });
+    expect(controls.latencyGuards.maxSourceMirrorDeltaMs).toBeGreaterThan(0);
+    expect(controls.latencyGuards.maxComparatorMs).toBeGreaterThan(0);
+  });
+
+  test("resolveAdminOrderListServingExperimentControls falls back to off for invalid experiment gate", () => {
+    process.env.ADMIN_ORDER_LIST_PG_SERVING_EXPERIMENT_GATE = "invalid_gate";
+
+    const controls = resolveAdminOrderListServingExperimentControls();
+
+    expect(controls.gate).toBe("off");
+    expect(controls.gateEnabled).toBe(false);
   });
 
   test("builds vendor rows with richer mirrored shape", () => {
@@ -1971,5 +1998,101 @@ describe("orderPostgresMirror", () => {
     expect(result.comparatorConfidence).toBe("low");
     expect(result.coverage).toEqual({ sourceCount: 1, mirroredCount: 1, coveredCount: 0 });
     expect(result.discrepancies).toEqual([]);
+  });
+
+  test("evaluateAdminOrderListServingExperimentReadiness blocks when gate is off", () => {
+    process.env.ADMIN_ORDER_LIST_PG_SERVING_EXPERIMENT_GATE = "off";
+
+    const readiness = evaluateAdminOrderListServingExperimentReadiness({
+      runtimeParity: {
+        match: true,
+        mismatchClass: null,
+        comparatorConfidence: "high",
+        discrepancies: [],
+        coverage: { sourceCount: 3, mirroredCount: 3, coveredCount: 3 },
+        queryContract: { status: "pending", page: 1, limit: 10 },
+        runtimeLatencyMs: { sourceQuery: 12, mirrorQuery: 11, comparator: 3, sourceMirrorDelta: 1 },
+      },
+    });
+
+    expect(readiness.eligible).toBe(false);
+    expect(readiness.blocked).toBe(true);
+    expect(readiness.blockedReasons).toContain("gate-disabled");
+    expect(readiness.servingPathDecision).toBe("blocked-legacy-only");
+  });
+
+  test("evaluateAdminOrderListServingExperimentReadiness blocks when kill switch is active", () => {
+    process.env.ADMIN_ORDER_LIST_PG_SERVING_EXPERIMENT_GATE = "ready";
+    process.env.ADMIN_ORDER_LIST_PG_SERVING_EXPERIMENT_KILL_SWITCH = "true";
+
+    const readiness = evaluateAdminOrderListServingExperimentReadiness({
+      runtimeParity: {
+        match: true,
+        mismatchClass: null,
+        comparatorConfidence: "high",
+        discrepancies: [],
+        coverage: { sourceCount: 2, mirroredCount: 2, coveredCount: 2 },
+        queryContract: { status: null, page: 1, limit: 20 },
+        runtimeLatencyMs: { sourceQuery: 14, mirrorQuery: 10, comparator: 2, sourceMirrorDelta: 4 },
+      },
+    });
+
+    expect(readiness.eligible).toBe(false);
+    expect(readiness.blockedReasons).toContain("kill-switch-active");
+    expect(readiness.failClosedDefaultLegacy).toBe(true);
+  });
+
+  test("evaluateAdminOrderListServingExperimentReadiness blocks when telemetry integrity is degraded", () => {
+    process.env.ADMIN_ORDER_LIST_PG_SERVING_EXPERIMENT_GATE = "ready";
+    delete process.env.ADMIN_ORDER_LIST_PG_SERVING_EXPERIMENT_KILL_SWITCH;
+
+    const readiness = evaluateAdminOrderListServingExperimentReadiness({
+      runtimeParity: {
+        match: false,
+        mismatchClass: "coverage-gap",
+        comparatorConfidence: "low",
+        discrepancies: [],
+        coverage: { sourceCount: 1, mirroredCount: 1, coveredCount: 0 },
+        queryContract: null,
+        runtimeLatencyMs: null,
+      },
+    });
+
+    expect(readiness.eligible).toBe(false);
+    expect(readiness.blockedReasons).toEqual(
+      expect.arrayContaining([
+        "telemetry-health-degraded",
+        "coverage-gap",
+        "mismatch-class-coverage-gap",
+      ])
+    );
+    expect(readiness.signals.comparatorHealth).toBe("healthy");
+    expect(readiness.signals.telemetryHealth).toBe("degraded");
+  });
+
+  test("evaluateAdminOrderListServingExperimentReadiness can classify eligible inputs while remaining non-serving", () => {
+    process.env.ADMIN_ORDER_LIST_PG_SERVING_EXPERIMENT_GATE = "ready";
+    process.env.ADMIN_ORDER_LIST_PG_SERVING_EXPERIMENT_KILL_SWITCH = "false";
+    process.env.ADMIN_ORDER_LIST_PG_READINESS_MAX_SOURCE_MIRROR_DELTA_MS = "50";
+    process.env.ADMIN_ORDER_LIST_PG_READINESS_MAX_COMPARATOR_MS = "50";
+
+    const readiness = evaluateAdminOrderListServingExperimentReadiness({
+      runtimeParity: {
+        match: true,
+        mismatchClass: null,
+        comparatorConfidence: "high",
+        discrepancies: [],
+        coverage: { sourceCount: 4, mirroredCount: 4, coveredCount: 4 },
+        queryContract: { status: "pending", page: 1, limit: 10 },
+        runtimeLatencyMs: { sourceQuery: 20, mirrorQuery: 18, comparator: 6, sourceMirrorDelta: 2 },
+      },
+    });
+
+    expect(readiness.eligible).toBe(true);
+    expect(readiness.blocked).toBe(false);
+    expect(readiness.blockedReasons).toEqual([]);
+    expect(readiness.signals.telemetryHealth).toBe("healthy");
+    expect(readiness.signals.comparatorHealth).toBe("healthy");
+    expect(readiness.servingPathDecision).toBe("eligible-for-future-experiment");
   });
 });

--- a/docs/issues/tran-admin-order-list-serving-experiment-readiness-controls.md
+++ b/docs/issues/tran-admin-order-list-serving-experiment-readiness-controls.md
@@ -1,0 +1,38 @@
+Scope Lock — TRAN: Admin order-list serving-experiment readiness controls
+
+**Objective**
+Add fail-closed readiness controls for a future admin order-list serving experiment while keeping Mongo as the only serving path in this slice. Produce structured readiness telemetry from existing runtime parity signals.
+
+**NEW canonical path**
+
+* Introduce explicit readiness control resolution for admin order-list experiment gate, kill switch, and bounded latency guard thresholds.
+* Evaluate readiness classification from runtime parity and comparator telemetry into deterministic blocked or eligible outputs.
+* Emit structured readiness telemetry on runtime verification paths.
+
+**LEGACY path still present**
+
+* Mongo-backed admin order-list remains the only production-serving source.
+* Existing API request and response payload semantics remain unchanged.
+* No PostgreSQL response serving is enabled.
+
+**TRANSITIONAL bridge path, if any**
+
+* Consume existing runtime read-shadow parity results as readiness inputs.
+* Keep all readiness outcomes non-serving and observability-only.
+* Preserve fail-closed behavior for invalid controls, missing parity, telemetry degradation, comparator errors, or mismatch classes.
+
+**Untouched surfaces**
+
+* No read cutover for any endpoint.
+* No write-path or dual-write behavior changes.
+* No schema or migration changes.
+* No customer order-list, vendor order-list, or order-detail scope expansion.
+* No frontend/UI contract changes.
+* No auth/role model changes.
+
+**Hard boundaries**
+
+* Restrict changes to admin order-list readiness controls, telemetry, and focused service tests.
+* No serving-path switch or routing fallback logic for PostgreSQL serving.
+* Keep behavior explicitly fail-closed to legacy serving defaults.
+* Keep PR in Draft until focused tests are green and readiness telemetry semantics are stable.


### PR DESCRIPTION
## Scope
TRAN slice for admin order-list serving-experiment readiness controls only.

## Governance
- Scope lock: docs/issues/tran-admin-order-list-serving-experiment-readiness-controls.md
- Issue: #98
- PR: #99 (Draft)
- Branch: tran-admin-order-list-serving-experiment-readiness-controls
- Current head: 60d150690ec84a7592c9e92201875c71231cfc24

## Exact Changed Files (deduplicated)
- backend/routes/adminOrders.js
- backend/services/orderPostgresMirror.js
- backend/tests/unit/routes/adminOrders.readinessControls.test.js
- backend/tests/unit/services/orderPostgresMirror.test.js
- docs/issues/tran-admin-order-list-serving-experiment-readiness-controls.md

## Exact Focused Test Commands Run
- cd /workspaces/Merkato/backend && npx jest --config=./jest.config.backend.js --runInBand tests/unit/services/orderPostgresMirror.test.js --reporters=default
- cd /workspaces/Merkato/backend && npx jest --config=./jest.config.backend.js --runInBand tests/unit/routes/adminOrders.readinessControls.test.js --reporters=default

## Readiness Controls Added
- Control resolution via env vars in backend/services/orderPostgresMirror.js:
  - ADMIN_ORDER_LIST_PG_SERVING_EXPERIMENT_GATE (allowed: off|ready, invalid -> off)
  - ADMIN_ORDER_LIST_PG_SERVING_EXPERIMENT_KILL_SWITCH (true activates kill switch)
  - ADMIN_ORDER_LIST_PG_READINESS_MAX_SOURCE_MIRROR_DELTA_MS (default 2500)
  - ADMIN_ORDER_LIST_PG_READINESS_MAX_COMPARATOR_MS (default 1500)
- Readiness evaluator returns eligible/blocked, blockedReasons, signals, evaluationInputs, servingPathDecision.
- Admin route emits readiness telemetry from runtime parity and from comparator-error fallback path.

## Fail-Closed Summary
- failClosedDefaultLegacy is explicit in controls and evaluation outputs.
- Any gate-off, kill-switch-active, comparator error, telemetry degradation, coverage gap, mismatch class, latency guard breach, or missing runtime parity remains blocked.
- servingPathDecision resolves to blocked-legacy-only when blocked.

## Focused Admin Route Proof (telemetry-only, non-serving)
- Route-level proof tests added in backend/tests/unit/routes/adminOrders.readinessControls.test.js:
  - "keeps readiness logic telemetry-only and serves Mongo orders"
  - "comparator or readiness failure cannot switch serving path"
- Admin orders route still responds from Mongo orders array and does not route to PostgreSQL serving.

## Explicit No-Switch Confirmation
- No serving-path switch introduced anywhere in this PR.
- Mongo remains the response source for GET /api/admin/orders.
- Comparator/parity/readiness failure is telemetry-only and cannot switch serving path.
