### PR TITLE
TRAN: Customer order-history serving-experiment readiness controls

### DIFF
--- a/backend/routes/orderRoutes.js
+++ b/backend/routes/orderRoutes.js
@@ -8,6 +8,7 @@ const Invoice = require('../models/Invoice');
 const ReturnRequest = require('../models/ReturnRequest');
 const { getPrismaClient } = require('../prisma/client');
 const {
+  evaluateCustomerOrderHistoryServingExperimentReadiness,
   evaluateCustomerOrderHistoryRuntimeShadowVerification,
   mirrorOrderCreationToPostgres,
   resolveOrdersPgMirrorMode,
@@ -101,8 +102,45 @@ async function handleCustomerOrderHistory(req, res, aliasPath) {
         aliasPath,
       });
 
+      const readiness = evaluateCustomerOrderHistoryServingExperimentReadiness({
+        runtimeParity,
+        aliasPath,
+      });
+
+      const servingDecisionTelemetry = {
+        event: 'customer-order-history-serving-experiment-decision',
+        aliasPath,
+        source: 'mongo',
+        reason: 'legacy-default',
+        readinessEligible: readiness.eligible,
+        blockedReasons: readiness.blockedReasons,
+        failClosedDefaultLegacy: readiness.failClosedDefaultLegacy,
+        controls: readiness.controls,
+      };
+
+      if (!readiness.eligible) {
+        const blockedReasons = Array.isArray(readiness.blockedReasons) ? readiness.blockedReasons : [];
+        servingDecisionTelemetry.reason = blockedReasons[0] || 'readiness-blocked';
+      } else {
+        // This slice remains non-serving even when telemetry indicates readiness eligibility.
+        servingDecisionTelemetry.reason = 'eligible-non-serving-slice';
+      }
+
+      const readinessTelemetry = {
+        event: 'customer-order-history-serving-experiment-readiness-controls',
+        aliasPath,
+        eligible: readiness.eligible,
+        blocked: readiness.blocked,
+        blockedReasons: readiness.blockedReasons,
+        failClosedDefaultLegacy: readiness.failClosedDefaultLegacy,
+        servingPathDecision: readiness.servingPathDecision,
+        controls: readiness.controls,
+        signals: readiness.signals,
+        evaluationInputs: readiness.evaluationInputs,
+      };
+
       if (runtimeParity) {
-        const telemetry = {
+        const parityTelemetry = {
           event: 'customer-order-history-runtime-read-shadow-verification',
           aliasPath,
           match: runtimeParity.match,
@@ -121,25 +159,60 @@ async function handleCustomerOrderHistory(req, res, aliasPath) {
           failClosedDefaultLegacy: true,
         };
 
-        if (!runtimeParity.match) {
-          console.warn(`[orders-postgres-mirror] ${JSON.stringify(telemetry)}`);
+        const gateOnlyBlock =
+          readiness.blocked &&
+          Array.isArray(readiness.blockedReasons) &&
+          readiness.blockedReasons.length === 1 &&
+          readiness.blockedReasons[0] === 'gate-disabled';
+
+        const decisionRequiresWarning =
+          servingDecisionTelemetry.reason !== 'legacy-default' && servingDecisionTelemetry.reason !== 'gate-disabled';
+
+        if (!runtimeParity.match || !gateOnlyBlock || decisionRequiresWarning) {
+          console.warn(`[orders-postgres-mirror] ${JSON.stringify(parityTelemetry)}`);
+          console.warn(`[orders-postgres-mirror] ${JSON.stringify(readinessTelemetry)}`);
+          console.warn(`[orders-postgres-mirror] ${JSON.stringify(servingDecisionTelemetry)}`);
         } else if (String(process.env.ORDERS_PG_MIRROR_LOG_SUCCESS || '').toLowerCase() === 'true') {
-          console.log(`[orders-postgres-mirror] ${JSON.stringify(telemetry)}`);
+          console.log(`[orders-postgres-mirror] ${JSON.stringify(parityTelemetry)}`);
+          console.log(`[orders-postgres-mirror] ${JSON.stringify(readinessTelemetry)}`);
+          console.log(`[orders-postgres-mirror] ${JSON.stringify(servingDecisionTelemetry)}`);
         }
+      } else {
+        console.warn(`[orders-postgres-mirror] ${JSON.stringify(readinessTelemetry)}`);
+        console.warn(`[orders-postgres-mirror] ${JSON.stringify(servingDecisionTelemetry)}`);
       }
     } catch (shadowError) {
       const message = shadowError && shadowError.message ? shadowError.message : String(shadowError);
+      const readiness = evaluateCustomerOrderHistoryServingExperimentReadiness({
+        runtimeParity: null,
+        comparatorError: message,
+        aliasPath,
+      });
+      console.warn(`[orders-postgres-mirror] customer-order-history runtime read-shadow verification skipped: ${message}`);
       console.warn(
         `[orders-postgres-mirror] ${JSON.stringify({
-          event: 'customer-order-history-runtime-read-shadow-verification',
+          event: 'customer-order-history-serving-experiment-readiness-controls',
           aliasPath,
-          match: false,
-          mismatchClass: 'comparator-error',
-          comparatorConfidence: 'low',
-          discrepancyCount: 1,
-          discrepancySamples: [message],
-          servingPathDecision: 'mongo-only-shadow-runtime',
-          failClosedDefaultLegacy: true,
+          eligible: readiness.eligible,
+          blocked: readiness.blocked,
+          blockedReasons: readiness.blockedReasons,
+          failClosedDefaultLegacy: readiness.failClosedDefaultLegacy,
+          servingPathDecision: readiness.servingPathDecision,
+          controls: readiness.controls,
+          signals: readiness.signals,
+          evaluationInputs: readiness.evaluationInputs,
+        })}`
+      );
+      console.warn(
+        `[orders-postgres-mirror] ${JSON.stringify({
+          event: 'customer-order-history-serving-experiment-decision',
+          aliasPath,
+          source: 'mongo',
+          reason: 'comparator-or-runtime-failure-fallback',
+          readinessEligible: readiness.eligible,
+          blockedReasons: readiness.blockedReasons,
+          failClosedDefaultLegacy: readiness.failClosedDefaultLegacy,
+          controls: readiness.controls,
         })}`
       );
     }

--- a/backend/services/orderPostgresMirror.js
+++ b/backend/services/orderPostgresMirror.js
@@ -13,6 +13,7 @@ const {
 
 const VALID_MIRROR_MODES = new Set(["off", "best_effort"]);
 const VALID_ADMIN_ORDER_LIST_EXPERIMENT_GATES = new Set(["off", "ready"]);
+const VALID_CUSTOMER_ORDER_HISTORY_EXPERIMENT_GATES = new Set(["off", "ready"]);
 
 function parsePositiveInteger(rawValue, fallbackValue) {
   const numeric = Number(rawValue);
@@ -47,6 +48,41 @@ function resolveAdminOrderListServingExperimentControls() {
       ),
       maxComparatorMs: parsePositiveInteger(
         process.env.ADMIN_ORDER_LIST_PG_READINESS_MAX_COMPARATOR_MS,
+        1500
+      ),
+    },
+  };
+}
+
+function resolveCustomerOrderHistoryServingExperimentControls() {
+  const gateRaw = String(process.env.CUSTOMER_ORDER_HISTORY_PG_SERVING_EXPERIMENT_GATE || "").trim().toLowerCase();
+  let gate = gateRaw || "off";
+  if (!VALID_CUSTOMER_ORDER_HISTORY_EXPERIMENT_GATES.has(gate)) {
+    if (gateRaw) {
+      console.warn(
+        `[orders-postgres-mirror] Invalid CUSTOMER_ORDER_HISTORY_PG_SERVING_EXPERIMENT_GATE="${gateRaw}". Falling back to off.`
+      );
+    }
+    gate = "off";
+  }
+
+  const killSwitchRaw = String(process.env.CUSTOMER_ORDER_HISTORY_PG_SERVING_EXPERIMENT_KILL_SWITCH || "")
+    .trim()
+    .toLowerCase();
+  const killSwitchActive = killSwitchRaw === "true";
+
+  return {
+    gate,
+    gateEnabled: gate === "ready",
+    killSwitchActive,
+    failClosedDefaultLegacy: true,
+    latencyGuards: {
+      maxSourceMirrorDeltaMs: parsePositiveInteger(
+        process.env.CUSTOMER_ORDER_HISTORY_PG_READINESS_MAX_SOURCE_MIRROR_DELTA_MS,
+        2500
+      ),
+      maxComparatorMs: parsePositiveInteger(
+        process.env.CUSTOMER_ORDER_HISTORY_PG_READINESS_MAX_COMPARATOR_MS,
         1500
       ),
     },
@@ -1180,6 +1216,112 @@ function evaluateCustomerOrderHistoryRuntimeShadowVerification(
   };
 }
 
+function evaluateCustomerOrderHistoryServingExperimentReadiness({ runtimeParity, comparatorError, aliasPath } = {}) {
+  const controls = resolveCustomerOrderHistoryServingExperimentControls();
+  const hasRuntimeParity = Boolean(runtimeParity && typeof runtimeParity === "object");
+  const runtimeLatency = hasRuntimeParity && runtimeParity.runtimeLatencyMs ? runtimeParity.runtimeLatencyMs : null;
+
+  const alias = aliasPath ? String(aliasPath) : null;
+  const supportedAliases = new Set(["/my-orders", "/my"]);
+  const aliasSupported = alias ? supportedAliases.has(alias) : false;
+  const runtimeAlias =
+    hasRuntimeParity && runtimeParity.queryContract && runtimeParity.queryContract.aliasPath
+      ? String(runtimeParity.queryContract.aliasPath)
+      : null;
+  const runtimeAliasSupported = runtimeAlias ? supportedAliases.has(runtimeAlias) : true;
+  const aliasContractAligned = Boolean(!alias || !runtimeAlias || alias === runtimeAlias);
+
+  const sourceMirrorDeltaMs = Number(runtimeLatency && runtimeLatency.sourceMirrorDelta);
+  const comparatorMs = Number(runtimeLatency && runtimeLatency.comparator);
+  const sourceMirrorDeltaExceeded =
+    Number.isFinite(sourceMirrorDeltaMs) && sourceMirrorDeltaMs > controls.latencyGuards.maxSourceMirrorDeltaMs;
+  const comparatorExceeded = Number.isFinite(comparatorMs) && comparatorMs > controls.latencyGuards.maxComparatorMs;
+
+  const comparatorHealthy =
+    hasRuntimeParity &&
+    Array.isArray(runtimeParity.discrepancies) &&
+    runtimeParity.coverage &&
+    Number.isFinite(Number(runtimeParity.coverage.coveredCount));
+
+  const telemetryHealthy =
+    hasRuntimeParity &&
+    runtimeParity.queryContract &&
+    runtimeParity.coverage &&
+    Number.isFinite(Number(runtimeParity.coverage.sourceCount)) &&
+    Number.isFinite(Number(runtimeParity.coverage.mirroredCount)) &&
+    Number.isFinite(Number(runtimeParity.coverage.coveredCount)) &&
+    runtimeLatency &&
+    Number.isFinite(Number(runtimeLatency.sourceQuery)) &&
+    Number.isFinite(Number(runtimeLatency.mirrorQuery)) &&
+    Number.isFinite(Number(runtimeLatency.comparator)) &&
+    Number.isFinite(Number(runtimeLatency.sourceMirrorDelta));
+
+  const mismatchClassSignal = hasRuntimeParity
+    ? runtimeParity.mismatchClass || "none"
+    : comparatorError
+      ? "comparator-error"
+      : "missing-runtime-parity";
+
+  const blockedReasons = [];
+  if (!controls.gateEnabled) blockedReasons.push("gate-disabled");
+  if (controls.killSwitchActive) blockedReasons.push("kill-switch-active");
+  if (comparatorError) blockedReasons.push("comparator-error");
+  if (!aliasSupported) blockedReasons.push("alias-contract-unsupported-request-path");
+  if (!runtimeAliasSupported) blockedReasons.push("alias-contract-runtime-unsupported");
+  if (!aliasContractAligned) blockedReasons.push("alias-contract-request-runtime-drift");
+  if (!telemetryHealthy) blockedReasons.push("telemetry-health-degraded");
+  if (!comparatorHealthy) blockedReasons.push("comparator-health-degraded");
+
+  const coverage = hasRuntimeParity && runtimeParity.coverage ? runtimeParity.coverage : null;
+  if (coverage && Number(coverage.coveredCount) <= 0) blockedReasons.push("coverage-gap");
+
+  if (hasRuntimeParity && runtimeParity.mismatchClass) {
+    blockedReasons.push(`mismatch-class-${runtimeParity.mismatchClass}`);
+  }
+  if (sourceMirrorDeltaExceeded) blockedReasons.push("latency-guard-source-mirror-delta-exceeded");
+  if (comparatorExceeded) blockedReasons.push("latency-guard-comparator-exceeded");
+  if (!hasRuntimeParity) blockedReasons.push("no-runtime-parity-signal");
+
+  const dedupedBlockedReasons = Array.from(new Set(blockedReasons));
+  const blocked = dedupedBlockedReasons.length > 0;
+  const eligible = !blocked;
+
+  return {
+    eligible,
+    blocked,
+    blockedReasons: dedupedBlockedReasons,
+    failClosedDefaultLegacy: true,
+    controls,
+    evaluationInputs: {
+      gate: controls.gate,
+      killSwitchActive: controls.killSwitchActive,
+      aliasPath: alias,
+      runtimeAliasPath: runtimeAlias,
+      aliasContractAligned,
+      mismatchClassSignal,
+      comparatorConfidence: hasRuntimeParity ? runtimeParity.comparatorConfidence || null : null,
+      discrepancyCount: hasRuntimeParity && Array.isArray(runtimeParity.discrepancies)
+        ? runtimeParity.discrepancies.length
+        : null,
+      coverage,
+      latencyMs: runtimeLatency,
+    },
+    signals: {
+      mismatchClass: mismatchClassSignal,
+      aliasContract: aliasContractAligned && aliasSupported && runtimeAliasSupported ? "aligned" : "degraded",
+      telemetryHealth: telemetryHealthy ? "healthy" : "degraded",
+      comparatorHealth: comparatorHealthy ? "healthy" : "degraded",
+      latencyGuard: {
+        sourceMirrorDeltaMs: Number.isFinite(sourceMirrorDeltaMs) ? sourceMirrorDeltaMs : null,
+        comparatorMs: Number.isFinite(comparatorMs) ? comparatorMs : null,
+        sourceMirrorDeltaExceeded,
+        comparatorExceeded,
+      },
+    },
+    servingPathDecision: blocked ? "blocked-legacy-only" : "eligible-for-future-experiment",
+  };
+}
+
 function evaluateAdminOrderListServingExperimentReadiness({ runtimeParity, comparatorError } = {}) {
   const controls = resolveAdminOrderListServingExperimentControls();
   const hasRuntimeParity = Boolean(runtimeParity && typeof runtimeParity === "object");
@@ -1850,6 +1992,7 @@ module.exports = {
   compareCanonicalIdentityCompleteness,
   compareCustomerOrderListSummaryShadowParity,
   compareOrderDetailShadowParity,
+  evaluateCustomerOrderHistoryServingExperimentReadiness,
   evaluateCustomerOrderHistoryRuntimeShadowVerification,
   evaluateAdminOrderListServingExperimentReadiness,
   evaluateAdminOrderListRuntimeShadowVerification,
@@ -1858,6 +2001,7 @@ module.exports = {
   enrichVendorsWithCanonicalIdentity,
   mirrorOrderCreationToPostgres,
   resolveBuyerExternalId,
+  resolveCustomerOrderHistoryServingExperimentControls,
   resolveOrderExternalId,
   resolveAdminOrderListServingExperimentControls,
   resolveOrdersPgMirrorMode,

--- a/backend/tests/unit/routes/orderRoutes.customerHistoryShadow.test.js
+++ b/backend/tests/unit/routes/orderRoutes.customerHistoryShadow.test.js
@@ -54,6 +54,7 @@ jest.mock("../../../middleware/authMiddleware", () => ({
 jest.mock("../../../services/orderPostgresMirror", () => ({
   mirrorOrderCreationToPostgres: jest.fn(),
   resolveOrdersPgMirrorMode: jest.fn(),
+  evaluateCustomerOrderHistoryServingExperimentReadiness: jest.fn(),
   evaluateCustomerOrderHistoryRuntimeShadowVerification: jest.fn(),
 }));
 
@@ -61,6 +62,7 @@ const Order = require("../../../models/Order");
 const { getPrismaClient } = require("../../../prisma/client");
 const {
   resolveOrdersPgMirrorMode,
+  evaluateCustomerOrderHistoryServingExperimentReadiness,
   evaluateCustomerOrderHistoryRuntimeShadowVerification,
 } = require("../../../services/orderPostgresMirror");
 const orderRoutes = require("../../../routes/orderRoutes");
@@ -127,6 +129,16 @@ describe("orderRoutes customer-history runtime shadow", () => {
       sourceResult: { total: 1, ids: ["order-1"] },
       mirroredResult: { total: 1, ids: ["order-1"] },
     });
+    evaluateCustomerOrderHistoryServingExperimentReadiness.mockReturnValue({
+      eligible: false,
+      blocked: true,
+      blockedReasons: ["gate-disabled"],
+      failClosedDefaultLegacy: true,
+      servingPathDecision: "blocked-legacy-only",
+      controls: { gate: "off", gateEnabled: false, killSwitchActive: false },
+      signals: { telemetryHealth: "healthy", comparatorHealth: "healthy", aliasContract: "aligned" },
+      evaluationInputs: { aliasPath: "/my-orders", mismatchClassSignal: "none" },
+    });
   });
 
   afterEach(() => {
@@ -143,7 +155,11 @@ describe("orderRoutes customer-history runtime shadow", () => {
     expect(myAliasRes.body).toEqual(myOrdersRes.body);
 
     const aliasesPassed = evaluateCustomerOrderHistoryRuntimeShadowVerification.mock.calls.map((call) => call[2].aliasPath);
+    const readinessAliases = evaluateCustomerOrderHistoryServingExperimentReadiness.mock.calls.map(
+      (call) => call[0].aliasPath
+    );
     expect(aliasesPassed).toEqual(["/my-orders", "/my"]);
+    expect(readinessAliases).toEqual(["/my-orders", "/my"]);
   });
 
   test("emits ownership mismatch telemetry while preserving Mongo serving response", async () => {
@@ -157,6 +173,16 @@ describe("orderRoutes customer-history runtime shadow", () => {
       sourceResult: { total: 1, ids: ["order-1"] },
       mirroredResult: { total: 0, ids: [] },
     });
+    evaluateCustomerOrderHistoryServingExperimentReadiness.mockReturnValue({
+      eligible: false,
+      blocked: true,
+      blockedReasons: ["mismatch-class-ownership-mismatch"],
+      failClosedDefaultLegacy: true,
+      servingPathDecision: "blocked-legacy-only",
+      controls: { gate: "ready", gateEnabled: true, killSwitchActive: false },
+      signals: { telemetryHealth: "healthy", comparatorHealth: "healthy", aliasContract: "aligned" },
+      evaluationInputs: { aliasPath: "/my-orders", mismatchClassSignal: "ownership-mismatch" },
+    });
 
     const res = await request(app).get("/api/orders/my-orders");
 
@@ -166,9 +192,39 @@ describe("orderRoutes customer-history runtime shadow", () => {
     expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("ownership-mismatch"));
   });
 
+  test("kill switch active keeps Mongo-only serving response", async () => {
+    evaluateCustomerOrderHistoryServingExperimentReadiness.mockReturnValue({
+      eligible: false,
+      blocked: true,
+      blockedReasons: ["kill-switch-active"],
+      failClosedDefaultLegacy: true,
+      servingPathDecision: "blocked-legacy-only",
+      controls: { gate: "ready", gateEnabled: true, killSwitchActive: true },
+      signals: { telemetryHealth: "healthy", comparatorHealth: "healthy", aliasContract: "aligned" },
+      evaluationInputs: { aliasPath: "/my-orders", mismatchClassSignal: "none" },
+    });
+
+    const res = await request(app).get("/api/orders/my-orders");
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(Array.isArray(res.body.orders)).toBe(true);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("kill-switch-active"));
+  });
+
   test("fails closed to Mongo response when runtime comparator throws", async () => {
     evaluateCustomerOrderHistoryRuntimeShadowVerification.mockImplementation(() => {
       throw new Error("forced-customer-comparator-failure");
+    });
+    evaluateCustomerOrderHistoryServingExperimentReadiness.mockReturnValue({
+      eligible: false,
+      blocked: true,
+      blockedReasons: ["comparator-error", "telemetry-health-degraded", "comparator-health-degraded"],
+      failClosedDefaultLegacy: true,
+      servingPathDecision: "blocked-legacy-only",
+      controls: { gate: "ready", gateEnabled: true, killSwitchActive: false },
+      signals: { telemetryHealth: "degraded", comparatorHealth: "degraded", aliasContract: "degraded" },
+      evaluationInputs: { aliasPath: "/my", mismatchClassSignal: "comparator-error" },
     });
 
     const res = await request(app).get("/api/orders/my");
@@ -177,5 +233,12 @@ describe("orderRoutes customer-history runtime shadow", () => {
     expect(res.body.success).toBe(true);
     expect(Array.isArray(res.body.orders)).toBe(true);
     expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("comparator-error"));
+    expect(evaluateCustomerOrderHistoryServingExperimentReadiness).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runtimeParity: null,
+        comparatorError: "forced-customer-comparator-failure",
+        aliasPath: "/my",
+      })
+    );
   });
 });

--- a/backend/tests/unit/services/orderPostgresMirror.test.js
+++ b/backend/tests/unit/services/orderPostgresMirror.test.js
@@ -7,6 +7,7 @@ const {
   compareCanonicalIdentityCompleteness,
   compareCustomerOrderListSummaryShadowParity,
   compareOrderDetailShadowParity,
+  evaluateCustomerOrderHistoryServingExperimentReadiness,
   evaluateCustomerOrderHistoryRuntimeShadowVerification,
   evaluateAdminOrderListServingExperimentReadiness,
   evaluateAdminOrderListRuntimeShadowVerification,
@@ -14,6 +15,7 @@ const {
   compareVendorOrderListSummaryShadowParity,
   enrichVendorsWithCanonicalIdentity,
   resolveAdminOrderListServingExperimentControls,
+  resolveCustomerOrderHistoryServingExperimentControls,
   resolveBuyerExternalId,
   resolveOrderExternalId,
   resolveOrdersPgMirrorMode,
@@ -58,6 +60,31 @@ describe("orderPostgresMirror", () => {
     process.env.ADMIN_ORDER_LIST_PG_SERVING_EXPERIMENT_GATE = "invalid_gate";
 
     const controls = resolveAdminOrderListServingExperimentControls();
+
+    expect(controls.gate).toBe("off");
+    expect(controls.gateEnabled).toBe(false);
+  });
+
+  test("resolveCustomerOrderHistoryServingExperimentControls defaults to fail-closed legacy behavior", () => {
+    delete process.env.CUSTOMER_ORDER_HISTORY_PG_SERVING_EXPERIMENT_GATE;
+    delete process.env.CUSTOMER_ORDER_HISTORY_PG_SERVING_EXPERIMENT_KILL_SWITCH;
+
+    const controls = resolveCustomerOrderHistoryServingExperimentControls();
+
+    expect(controls).toMatchObject({
+      gate: "off",
+      gateEnabled: false,
+      killSwitchActive: false,
+      failClosedDefaultLegacy: true,
+    });
+    expect(controls.latencyGuards.maxSourceMirrorDeltaMs).toBeGreaterThan(0);
+    expect(controls.latencyGuards.maxComparatorMs).toBeGreaterThan(0);
+  });
+
+  test("resolveCustomerOrderHistoryServingExperimentControls falls back to off for invalid experiment gate", () => {
+    process.env.CUSTOMER_ORDER_HISTORY_PG_SERVING_EXPERIMENT_GATE = "invalid_gate";
+
+    const controls = resolveCustomerOrderHistoryServingExperimentControls();
 
     expect(controls.gate).toBe("off");
     expect(controls.gateEnabled).toBe(false);
@@ -1928,6 +1955,143 @@ describe("orderPostgresMirror", () => {
         expect.stringContaining("alias.contract.unsupported:/orders/history"),
       ])
     );
+  });
+
+  test("evaluateCustomerOrderHistoryServingExperimentReadiness blocks when gate is off", () => {
+    process.env.CUSTOMER_ORDER_HISTORY_PG_SERVING_EXPERIMENT_GATE = "off";
+
+    const readiness = evaluateCustomerOrderHistoryServingExperimentReadiness({
+      runtimeParity: {
+        match: true,
+        mismatchClass: null,
+        comparatorConfidence: "high",
+        discrepancies: [],
+        coverage: { sourceCount: 2, mirroredCount: 2, coveredCount: 2 },
+        queryContract: { buyerMongoId: "buyer-1", aliasPath: "/my-orders" },
+        runtimeLatencyMs: { sourceQuery: 12, mirrorQuery: 11, comparator: 3, sourceMirrorDelta: 1 },
+      },
+      aliasPath: "/my-orders",
+    });
+
+    expect(readiness.eligible).toBe(false);
+    expect(readiness.blocked).toBe(true);
+    expect(readiness.blockedReasons).toContain("gate-disabled");
+    expect(readiness.servingPathDecision).toBe("blocked-legacy-only");
+  });
+
+  test("evaluateCustomerOrderHistoryServingExperimentReadiness blocks when kill switch is active", () => {
+    process.env.CUSTOMER_ORDER_HISTORY_PG_SERVING_EXPERIMENT_GATE = "ready";
+    process.env.CUSTOMER_ORDER_HISTORY_PG_SERVING_EXPERIMENT_KILL_SWITCH = "true";
+
+    const readiness = evaluateCustomerOrderHistoryServingExperimentReadiness({
+      runtimeParity: {
+        match: true,
+        mismatchClass: null,
+        comparatorConfidence: "high",
+        discrepancies: [],
+        coverage: { sourceCount: 2, mirroredCount: 2, coveredCount: 2 },
+        queryContract: { buyerMongoId: "buyer-1", aliasPath: "/my" },
+        runtimeLatencyMs: { sourceQuery: 14, mirrorQuery: 10, comparator: 2, sourceMirrorDelta: 4 },
+      },
+      aliasPath: "/my",
+    });
+
+    expect(readiness.eligible).toBe(false);
+    expect(readiness.blockedReasons).toContain("kill-switch-active");
+    expect(readiness.failClosedDefaultLegacy).toBe(true);
+  });
+
+  test("evaluateCustomerOrderHistoryServingExperimentReadiness blocks when telemetry integrity is degraded", () => {
+    process.env.CUSTOMER_ORDER_HISTORY_PG_SERVING_EXPERIMENT_GATE = "ready";
+    delete process.env.CUSTOMER_ORDER_HISTORY_PG_SERVING_EXPERIMENT_KILL_SWITCH;
+
+    const readiness = evaluateCustomerOrderHistoryServingExperimentReadiness({
+      runtimeParity: {
+        match: false,
+        mismatchClass: "coverage-gap",
+        comparatorConfidence: "low",
+        discrepancies: [],
+        coverage: { sourceCount: 1, mirroredCount: 1, coveredCount: 0 },
+        queryContract: null,
+        runtimeLatencyMs: null,
+      },
+      aliasPath: "/my-orders",
+    });
+
+    expect(readiness.eligible).toBe(false);
+    expect(readiness.blockedReasons).toEqual(
+      expect.arrayContaining([
+        "telemetry-health-degraded",
+        "coverage-gap",
+        "mismatch-class-coverage-gap",
+      ])
+    );
+    expect(readiness.signals.comparatorHealth).toBe("healthy");
+    expect(readiness.signals.telemetryHealth).toBe("degraded");
+  });
+
+  test("evaluateCustomerOrderHistoryServingExperimentReadiness fails closed on comparator/runtime error", () => {
+    process.env.CUSTOMER_ORDER_HISTORY_PG_SERVING_EXPERIMENT_GATE = "ready";
+    delete process.env.CUSTOMER_ORDER_HISTORY_PG_SERVING_EXPERIMENT_KILL_SWITCH;
+
+    const readiness = evaluateCustomerOrderHistoryServingExperimentReadiness({
+      runtimeParity: null,
+      comparatorError: "forced-customer-comparator-failure",
+      aliasPath: "/my",
+    });
+
+    expect(readiness.eligible).toBe(false);
+    expect(readiness.blocked).toBe(true);
+    expect(readiness.blockedReasons).toEqual(
+      expect.arrayContaining([
+        "comparator-error",
+        "telemetry-health-degraded",
+        "comparator-health-degraded",
+        "no-runtime-parity-signal",
+      ])
+    );
+    expect(readiness.servingPathDecision).toBe("blocked-legacy-only");
+  });
+
+  test("evaluateCustomerOrderHistoryServingExperimentReadiness keeps alias classification consistent for /my-orders and /my", () => {
+    process.env.CUSTOMER_ORDER_HISTORY_PG_SERVING_EXPERIMENT_GATE = "ready";
+    process.env.CUSTOMER_ORDER_HISTORY_PG_SERVING_EXPERIMENT_KILL_SWITCH = "false";
+    process.env.CUSTOMER_ORDER_HISTORY_PG_READINESS_MAX_SOURCE_MIRROR_DELTA_MS = "50";
+    process.env.CUSTOMER_ORDER_HISTORY_PG_READINESS_MAX_COMPARATOR_MS = "50";
+
+    const baselineRuntimeParity = {
+      match: true,
+      mismatchClass: null,
+      comparatorConfidence: "high",
+      discrepancies: [],
+      coverage: { sourceCount: 3, mirroredCount: 3, coveredCount: 3 },
+      runtimeLatencyMs: { sourceQuery: 20, mirrorQuery: 18, comparator: 6, sourceMirrorDelta: 2 },
+    };
+
+    const myOrdersReadiness = evaluateCustomerOrderHistoryServingExperimentReadiness({
+      runtimeParity: {
+        ...baselineRuntimeParity,
+        queryContract: { buyerMongoId: "buyer-1", aliasPath: "/my-orders" },
+      },
+      aliasPath: "/my-orders",
+    });
+
+    const myAliasReadiness = evaluateCustomerOrderHistoryServingExperimentReadiness({
+      runtimeParity: {
+        ...baselineRuntimeParity,
+        queryContract: { buyerMongoId: "buyer-1", aliasPath: "/my" },
+      },
+      aliasPath: "/my",
+    });
+
+    expect(myOrdersReadiness.eligible).toBe(true);
+    expect(myAliasReadiness.eligible).toBe(true);
+    expect(myOrdersReadiness.blocked).toBe(false);
+    expect(myAliasReadiness.blocked).toBe(false);
+    expect(myOrdersReadiness.blockedReasons).toEqual([]);
+    expect(myAliasReadiness.blockedReasons).toEqual([]);
+    expect(myOrdersReadiness.servingPathDecision).toBe("eligible-for-future-experiment");
+    expect(myAliasReadiness.servingPathDecision).toBe("eligible-for-future-experiment");
   });
 
   test("evaluateAdminOrderListRuntimeShadowVerification reports match with high confidence when covered window parity holds", () => {

--- a/docs/issues/tran-customer-order-history-serving-readiness-controls.md
+++ b/docs/issues/tran-customer-order-history-serving-readiness-controls.md
@@ -1,0 +1,61 @@
+Scope Lock — TRAN: Customer order-history serving-experiment readiness controls
+
+Objective
+Add fail-closed readiness controls for customer order-history migration progression while keeping Mongo as the only serving source in this slice.
+
+NEW canonical path
+
+- Introduce explicit customer order-history serving-experiment controls:
+  - experiment gate state
+  - kill-switch state
+  - bounded readiness thresholds derived from runtime shadow telemetry
+- Add deterministic readiness evaluation for customer history aliases (/api/orders/my-orders and /api/orders/my) that classifies blocked versus eligible based on:
+  - mismatch class signals
+  - coverage health
+  - telemetry integrity
+  - comparator/runtime error signals
+  - latency guard thresholds
+- Emit structured readiness-decision telemetry for both aliases with explicit blocked reasons and fail-closed markers.
+- Add focused rollback-rehearsal checks proving immediate fallback intent under kill-switch and degraded/comparator-failure conditions.
+
+LEGACY path still present
+
+- Mongo-backed customer order-history remains the only serving source.
+- Existing request and response behavior for customer history remains authoritative.
+- No PostgreSQL-serving response path is enabled.
+
+TRANSITIONAL bridge path, if any
+
+- Consume existing runtime shadow verification outputs as readiness inputs only.
+- Keep all readiness outcomes non-serving and evidence-only.
+- Preserve fail-closed behavior: uncertainty, degradation, or comparator/runtime failure remains blocked-legacy-only.
+
+Untouched surfaces
+
+- No admin route work.
+- No vendor or product migration work.
+- No schema changes.
+- No write-path or dual-write changes.
+- No guest-order retrieval expansion in this slice unless already covered by existing customer parity/read contract evidence.
+- No frontend contract expansion.
+- No migration orchestration/backfill execution.
+
+Hard boundaries
+
+- Restrict changes to customer order-history readiness controls, decision telemetry, rollback rehearsal checks, and focused tests.
+- No serving-path switch logic.
+- No cutover behavior or PostgreSQL-serving routing fallback.
+- Keep PR in Draft until focused evidence and CI are complete and green.
+- Keep rollback-rehearsal proof scoped to focused runtime behavior checks only; no broader tooling or framework work.
+
+Acceptance evidence required in PR
+
+- Focused tests proving:
+  - gate off => blocked-legacy-only
+  - kill switch active => blocked-legacy-only
+  - readiness blocked classes remain non-serving
+  - comparator/runtime failure remains fail-closed
+  - alias-consistent readiness classification for /my-orders and /my
+  - rollback-rehearsal fallback behavior is explicit and immediate
+- CI green with no schema changes and no write-path changes.
+- Published readiness telemetry samples showing blocked reasons and rollback-rehearsal outcomes.


### PR DESCRIPTION
## Tranche\nCustomer Order Visibility and History Migration Tranche\n\n## Scope\nCustomer order-history serving-experiment readiness controls (fail-closed, non-serving).\n\n## Governance\n- Scope lock: docs/issues/tran-customer-order-history-serving-readiness-controls.md\n- Issue: #104\n\n## Guardrails\n- Fail-closed readiness controls\n- Kill-switch semantics\n- Blocked/eligible classification\n- Alias-consistent readiness behavior for /my-orders and /my\n- Non-serving only\n- No guest expansion\n- No schema work\n- No write-path work\n\n## Note\nRollback-rehearsal proof remains focused to runtime behavior checks only (no broader tooling/framework work).