### PR TITLE
Scope Lock — TRAN: Guarded customer order-history serving-path experiment

### DIFF
--- a/backend/routes/orderRoutes.js
+++ b/backend/routes/orderRoutes.js
@@ -38,6 +38,94 @@ function normalizeCustomerOrdersForResponse(orders) {
   });
 }
 
+function parseMoneyOrZero(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : 0;
+}
+
+function mapMirroredCustomerOrderToCoveredHistoryResponse(order) {
+  const mirrored = order && typeof order === 'object' ? order : {};
+  const vendors = Array.isArray(mirrored.vendors) ? mirrored.vendors : [];
+
+  return {
+    _id: mirrored.mongoId || null,
+    orderExternalId: mirrored.orderExternalId || null,
+    buyer: mirrored.buyerMongoId || null,
+    status: mirrored.status || 'pending',
+    currency: mirrored.currency || 'USD',
+    paymentMethod: mirrored.paymentMethod || 'cod',
+    total: parseMoneyOrZero(mirrored.total),
+    totalAfterDiscount: parseMoneyOrZero(mirrored.totalAfterDiscount),
+    discount: parseMoneyOrZero(mirrored.discount),
+    createdAt: mirrored.sourceCreatedAt || mirrored.createdAt || mirrored.orderDate || mirrored.mirroredAt || null,
+    vendors: vendors.map((vendor) => {
+      const items = Array.isArray(vendor && vendor.items) ? vendor.items : [];
+      return {
+        vendorId: vendor && vendor.vendorMongoId ? vendor.vendorMongoId : null,
+        vendorExternalId: vendor && vendor.vendorExternalId ? vendor.vendorExternalId : null,
+        vendorName: vendor && vendor.vendorName ? vendor.vendorName : null,
+        status: vendor && vendor.status ? vendor.status : 'pending',
+        currency: vendor && vendor.currency ? vendor.currency : (mirrored.currency || 'USD'),
+        subtotal: parseMoneyOrZero(vendor && vendor.subtotal),
+        discount: parseMoneyOrZero(vendor && vendor.discount),
+        tax: parseMoneyOrZero(vendor && vendor.tax),
+        shipping: parseMoneyOrZero(vendor && vendor.shipping),
+        total: parseMoneyOrZero(vendor && vendor.total),
+        products: items.map((item) => ({
+          product: item && item.productMongoId ? item.productMongoId : null,
+          name: item && item.name ? item.name : null,
+          quantity: Number(item && item.quantity) || 0,
+          price: parseMoneyOrZero(item && item.price),
+          subtotal: parseMoneyOrZero(item && item.subtotal),
+          tax: parseMoneyOrZero(item && item.tax),
+        })),
+      };
+    }),
+  };
+}
+
+function buildGuardedCustomerOrderHistoryPostgresResponse(runtimeParity) {
+  const mirroredOrders = runtimeParity && Array.isArray(runtimeParity.mirroredOrders)
+    ? runtimeParity.mirroredOrders
+    : [];
+  const mirroredResultIds = runtimeParity && runtimeParity.mirroredResult && Array.isArray(runtimeParity.mirroredResult.ids)
+    ? runtimeParity.mirroredResult.ids
+    : null;
+
+  if (!mirroredResultIds) {
+    return {
+      ok: false,
+      reason: 'missing-mirrored-window',
+      orders: [],
+    };
+  }
+
+  const mirroredOrderByMongoId = new Map(
+    mirroredOrders
+      .filter((order) => order && order.mongoId)
+      .map((order) => [String(order.mongoId), order])
+  );
+
+  const responseWindow = [];
+  for (const id of mirroredResultIds) {
+    const mirroredOrder = mirroredOrderByMongoId.get(String(id));
+    if (!mirroredOrder) {
+      return {
+        ok: false,
+        reason: 'covered-window-incomplete',
+        orders: [],
+      };
+    }
+    responseWindow.push(mapMirroredCustomerOrderToCoveredHistoryResponse(mirroredOrder));
+  }
+
+  return {
+    ok: true,
+    reason: 'eligible-guarded-serving',
+    orders: responseWindow,
+  };
+}
+
 async function runCustomerOrderHistoryRuntimeShadowVerification({ sourceOrders, sourceQueryMs, buyerMongoId, aliasPath }) {
   const mode = resolveOrdersPgMirrorMode();
   if (mode === 'off') return null;
@@ -75,6 +163,7 @@ async function runCustomerOrderHistoryRuntimeShadowVerification({ sourceOrders, 
 
   return {
     ...comparison,
+    mirroredOrders,
     runtimeLatencyMs: {
       sourceQuery: sourceQueryMs,
       mirrorQuery: mirrorQueryMs,
@@ -94,6 +183,7 @@ async function handleCustomerOrderHistory(req, res, aliasPath) {
     const orders = normalizeCustomerOrdersForResponse(rawOrders);
 
     const sourceQueryMs = Date.now() - sourceQueryStart;
+    let responseOrders = orders;
     try {
       const runtimeParity = await runCustomerOrderHistoryRuntimeShadowVerification({
         sourceOrders: orders,
@@ -122,8 +212,14 @@ async function handleCustomerOrderHistory(req, res, aliasPath) {
         const blockedReasons = Array.isArray(readiness.blockedReasons) ? readiness.blockedReasons : [];
         servingDecisionTelemetry.reason = blockedReasons[0] || 'readiness-blocked';
       } else {
-        // This slice remains non-serving even when telemetry indicates readiness eligibility.
-        servingDecisionTelemetry.reason = 'eligible-non-serving-slice';
+        const postgresResponse = buildGuardedCustomerOrderHistoryPostgresResponse(runtimeParity);
+        if (postgresResponse.ok) {
+          responseOrders = postgresResponse.orders;
+          servingDecisionTelemetry.source = 'postgres-covered-experiment';
+          servingDecisionTelemetry.reason = postgresResponse.reason;
+        } else {
+          servingDecisionTelemetry.reason = postgresResponse.reason;
+        }
       }
 
       const readinessTelemetry = {
@@ -155,7 +251,10 @@ async function handleCustomerOrderHistory(req, res, aliasPath) {
           sourceResult: runtimeParity.sourceResult,
           mirroredResult: runtimeParity.mirroredResult,
           latencyMs: runtimeParity.runtimeLatencyMs,
-          servingPathDecision: 'mongo-only-shadow-runtime',
+          servingPathDecision:
+            servingDecisionTelemetry.source === 'postgres-covered-experiment'
+              ? 'postgres-covered-experiment'
+              : 'mongo-only-shadow-runtime',
           failClosedDefaultLegacy: true,
         };
 
@@ -217,7 +316,7 @@ async function handleCustomerOrderHistory(req, res, aliasPath) {
       );
     }
 
-    return res.json({ success: true, orders });
+    return res.json({ success: true, orders: responseOrders });
   } catch (err) {
     return res.status(500).json({ message: err.message });
   }

--- a/backend/tests/unit/routes/orderRoutes.customerHistoryShadow.test.js
+++ b/backend/tests/unit/routes/orderRoutes.customerHistoryShadow.test.js
@@ -212,6 +212,199 @@ describe("orderRoutes customer-history runtime shadow", () => {
     expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("kill-switch-active"));
   });
 
+  test("eligible guarded path may serve covered PostgreSQL response", async () => {
+    getPrismaClient.mockReturnValue({
+      orderMirror: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            mongoId: "order-1",
+            orderExternalId: "oid_aaaaaaaaaaaaaaaaaaaa",
+            buyerMongoId: "buyer-1",
+            status: "pending",
+            currency: "USD",
+            paymentMethod: "cod",
+            total: "35.00",
+            totalAfterDiscount: "30.00",
+            discount: "5.00",
+            sourceCreatedAt: "2024-02-02T00:00:00.000Z",
+            vendors: [
+              {
+                vendorMongoId: "vendor-1",
+                vendorName: "Vendor One",
+                status: "pending",
+                currency: "USD",
+                subtotal: "30.00",
+                discount: "5.00",
+                tax: "0.00",
+                shipping: "0.00",
+                total: "30.00",
+                items: [
+                  {
+                    productMongoId: "product-1",
+                    name: "Mirror Widget",
+                    quantity: 1,
+                    price: "30.00",
+                    subtotal: "30.00",
+                    tax: "0.00",
+                  },
+                ],
+              },
+            ],
+          },
+        ]),
+      },
+    });
+
+    evaluateCustomerOrderHistoryRuntimeShadowVerification.mockReturnValue({
+      match: true,
+      mismatchClass: null,
+      comparatorConfidence: "high",
+      discrepancies: [],
+      coverage: { sourceCount: 1, mirroredCount: 1, coveredCount: 1 },
+      queryContract: { buyerMongoId: "buyer-1", aliasPath: "/my-orders" },
+      sourceResult: { total: 1, ids: ["order-1"] },
+      mirroredResult: { total: 1, ids: ["order-1"] },
+      runtimeLatencyMs: { sourceQuery: 12, mirrorQuery: 10, comparator: 2, sourceMirrorDelta: 2 },
+    });
+    evaluateCustomerOrderHistoryServingExperimentReadiness.mockReturnValue({
+      eligible: true,
+      blocked: false,
+      blockedReasons: [],
+      failClosedDefaultLegacy: true,
+      servingPathDecision: "eligible-for-future-experiment",
+      controls: { gate: "ready", gateEnabled: true, killSwitchActive: false },
+      signals: { telemetryHealth: "healthy", comparatorHealth: "healthy", aliasContract: "aligned" },
+      evaluationInputs: { aliasPath: "/my-orders", mismatchClassSignal: "none" },
+    });
+
+    const res = await request(app).get("/api/orders/my-orders");
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.orders).toEqual([
+      {
+        _id: "order-1",
+        orderExternalId: "oid_aaaaaaaaaaaaaaaaaaaa",
+        buyer: "buyer-1",
+        status: "pending",
+        currency: "USD",
+        paymentMethod: "cod",
+        total: 35,
+        totalAfterDiscount: 30,
+        discount: 5,
+        createdAt: "2024-02-02T00:00:00.000Z",
+        vendors: [
+          {
+            vendorId: "vendor-1",
+            vendorExternalId: null,
+            vendorName: "Vendor One",
+            status: "pending",
+            currency: "USD",
+            subtotal: 30,
+            discount: 5,
+            tax: 0,
+            shipping: 0,
+            total: 30,
+            products: [
+              {
+                product: "product-1",
+                name: "Mirror Widget",
+                quantity: 1,
+                price: 30,
+                subtotal: 30,
+                tax: 0,
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("postgres-covered-experiment"));
+  });
+
+  test("eligible guarded path stays alias-consistent for /my-orders and /my", async () => {
+    evaluateCustomerOrderHistoryRuntimeShadowVerification.mockReturnValue({
+      match: true,
+      mismatchClass: null,
+      comparatorConfidence: "high",
+      discrepancies: [],
+      coverage: { sourceCount: 1, mirroredCount: 1, coveredCount: 1 },
+      queryContract: { buyerMongoId: "buyer-1", aliasPath: "/my-orders" },
+      sourceResult: { total: 1, ids: ["order-1"] },
+      mirroredResult: { total: 1, ids: ["order-1"] },
+      mirroredOrders: [
+        {
+          mongoId: "order-1",
+          buyerMongoId: "buyer-1",
+          status: "pending",
+          currency: "USD",
+          paymentMethod: "cod",
+          total: "35.00",
+          totalAfterDiscount: "30.00",
+          discount: "5.00",
+          sourceCreatedAt: "2024-02-02T00:00:00.000Z",
+          vendors: [{ items: [] }],
+        },
+      ],
+      runtimeLatencyMs: { sourceQuery: 12, mirrorQuery: 10, comparator: 2, sourceMirrorDelta: 2 },
+    });
+    evaluateCustomerOrderHistoryServingExperimentReadiness.mockReturnValue({
+      eligible: true,
+      blocked: false,
+      blockedReasons: [],
+      failClosedDefaultLegacy: true,
+      servingPathDecision: "eligible-for-future-experiment",
+      controls: { gate: "ready", gateEnabled: true, killSwitchActive: false },
+      signals: { telemetryHealth: "healthy", comparatorHealth: "healthy", aliasContract: "aligned" },
+      evaluationInputs: { aliasPath: "/my-orders", mismatchClassSignal: "none" },
+    });
+
+    const myOrdersRes = await request(app).get("/api/orders/my-orders");
+    const myAliasRes = await request(app).get("/api/orders/my");
+
+    expect(myOrdersRes.statusCode).toBe(200);
+    expect(myAliasRes.statusCode).toBe(200);
+    expect(myAliasRes.body).toEqual(myOrdersRes.body);
+  });
+
+  test("eligible guarded path fails closed to Mongo when covered mirrored window is incomplete", async () => {
+    getPrismaClient.mockReturnValue({
+      orderMirror: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+    });
+
+    evaluateCustomerOrderHistoryRuntimeShadowVerification.mockReturnValue({
+      match: true,
+      mismatchClass: null,
+      comparatorConfidence: "high",
+      discrepancies: [],
+      coverage: { sourceCount: 1, mirroredCount: 1, coveredCount: 1 },
+      queryContract: { buyerMongoId: "buyer-1", aliasPath: "/my-orders" },
+      sourceResult: { total: 1, ids: ["order-1"] },
+      mirroredResult: { total: 1, ids: ["order-1"] },
+      runtimeLatencyMs: { sourceQuery: 12, mirrorQuery: 10, comparator: 2, sourceMirrorDelta: 2 },
+    });
+    evaluateCustomerOrderHistoryServingExperimentReadiness.mockReturnValue({
+      eligible: true,
+      blocked: false,
+      blockedReasons: [],
+      failClosedDefaultLegacy: true,
+      servingPathDecision: "eligible-for-future-experiment",
+      controls: { gate: "ready", gateEnabled: true, killSwitchActive: false },
+      signals: { telemetryHealth: "healthy", comparatorHealth: "healthy", aliasContract: "aligned" },
+      evaluationInputs: { aliasPath: "/my-orders", mismatchClassSignal: "none" },
+    });
+
+    const res = await request(app).get("/api/orders/my-orders");
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(Array.isArray(res.body.orders)).toBe(true);
+    expect(res.body.orders[0]).toMatchObject({ _id: "order-1" });
+    expect(consoleWarnSpy).toHaveBeenCalledWith(expect.stringContaining("covered-window-incomplete"));
+  });
+
   test("fails closed to Mongo response when runtime comparator throws", async () => {
     evaluateCustomerOrderHistoryRuntimeShadowVerification.mockImplementation(() => {
       throw new Error("forced-customer-comparator-failure");

--- a/docs/issues/tran-customer-order-history-guarded-serving-path-experiment.md
+++ b/docs/issues/tran-customer-order-history-guarded-serving-path-experiment.md
@@ -1,0 +1,45 @@
+Scope Lock — TRAN: Guarded customer order-history serving-path experiment
+
+Objective
+Introduce a tightly guarded, fail-closed customer order-history serving-path experiment for customer history endpoints only, while preserving Mongo as default serving unless explicit guarded conditions are satisfied.
+
+In-scope surface
+- Customer order-history only.
+- Alias-consistent behavior for /my-orders and /my.
+- Covered customer history read contract only.
+
+TRANSITIONAL guarded path
+- Add guarded serving decision logic for customer order-history that may serve covered PostgreSQL responses only when all readiness controls are explicitly eligible.
+- Keep fail-closed default behavior at all times.
+- Require alias contract alignment, telemetry health, comparator health, coverage health, and latency guard compliance before any guarded PostgreSQL serving decision.
+- Emit structured serving-decision telemetry and readiness telemetry for both aliases with explicit blocked reasons and decision source.
+
+Guardrails and rollback behavior
+- Mongo remains default serving source unless guarded eligibility is explicitly satisfied.
+- Immediate rollback behavior is mandatory:
+- Kill switch active must force blocked-legacy-only and immediate Mongo serving.
+- Any comparator/runtime failure must force blocked-legacy-only and immediate Mongo serving.
+- Any readiness degradation must force blocked-legacy-only and immediate Mongo serving.
+
+Out of scope
+- No guest-order retrieval expansion.
+- No schema work.
+- No write-path work.
+- No dual-write expansion.
+- No scope expansion outside covered customer history contract.
+- No domain pivot outside Customer Order Visibility and History Migration Tranche.
+
+Hard boundaries
+- Restrict changes to guarded serving decisioning for customer order-history, rollback controls, and focused proofs only.
+- No unrelated route changes.
+- No admin or vendor tranche work.
+
+Evidence-first acceptance requirements
+- Focused tests proving:
+- Gate off returns blocked-legacy-only and Mongo serves.
+- Kill switch active returns blocked-legacy-only and Mongo serves immediately.
+- Comparator/runtime failure is fail-closed and Mongo serves immediately.
+- Alias-consistent guarded behavior for /my-orders and /my.
+- Eligible guarded case serves covered PostgreSQL response only under explicit readiness eligibility.
+- Any eligibility drift reverts immediately to Mongo serving.
+- Focused command evidence and CI green required before transition out of Draft.


### PR DESCRIPTION
Scope Lock — TRAN: Guarded customer order-history serving-path experiment

Objective
Introduce a tightly guarded, fail-closed customer order-history serving-path experiment for customer history endpoints only, while preserving Mongo as default serving unless explicit guarded conditions are satisfied.

In-scope surface
- Customer order-history only.
- Alias-consistent behavior for /my-orders and /my.
- Covered customer history read contract only.

TRANSITIONAL guarded path
- Add guarded serving decision logic for customer order-history that may serve covered PostgreSQL responses only when all readiness controls are explicitly eligible.
- Keep fail-closed default behavior at all times.
- Require alias contract alignment, telemetry health, comparator health, coverage health, and latency guard compliance before any guarded PostgreSQL serving decision.
- Emit structured serving-decision telemetry and readiness telemetry for both aliases with explicit blocked reasons and decision source.

Guardrails and rollback behavior
- Mongo remains default serving source unless guarded eligibility is explicitly satisfied.
- Immediate rollback behavior is mandatory:
- Kill switch active must force blocked-legacy-only and immediate Mongo serving.
- Any comparator/runtime failure must force blocked-legacy-only and immediate Mongo serving.
- Any readiness degradation must force blocked-legacy-only and immediate Mongo serving.

Out of scope
- No guest-order retrieval expansion.
- No schema work.
- No write-path work.
- No dual-write expansion.
- No scope expansion outside covered customer history contract.
- No domain pivot outside Customer Order Visibility and History Migration Tranche.

Hard boundaries
- Restrict changes to guarded serving decisioning for customer order-history, rollback controls, and focused proofs only.
- No unrelated route changes.
- No admin or vendor tranche work.

Evidence-first acceptance requirements
- Focused tests proving:
- Gate off returns blocked-legacy-only and Mongo serves.
- Kill switch active returns blocked-legacy-only and Mongo serves immediately.
- Comparator/runtime failure is fail-closed and Mongo serves immediately.
- Alias-consistent guarded behavior for /my-orders and /my.
- Eligible guarded case serves covered PostgreSQL response only under explicit readiness eligibility.
- Any eligibility drift reverts immediately to Mongo serving.
- Focused command evidence and CI green required before transition out of Draft.
